### PR TITLE
ci: add nix build verification to GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,24 @@ jobs:
         name: coverage-report
         path: coverage.out
         retention-days: 7
+
+  nix-build:
+    name: Nix Build
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install Nix
+      uses: cachix/install-nix-action@v30
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+        extra_nix_config: |
+          experimental-features = nix-command flakes
+
+    - name: Run nix build
+      run: nix build
+
+    - name: Verify built binary
+      run: ./result/bin/ign --help

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ result
 
 ## go binaries
 /ign
+/vendor/

--- a/flake.nix
+++ b/flake.nix
@@ -148,7 +148,7 @@
 
             src = ./.;
 
-            vendorHash = "sha256-7K17JaXFsjf163g5PXCb5ng2gYdotnZ2IDKk8KFjNj0=";
+            vendorHash = "sha256-esmcKwW2KbmEXIukBKUZgN32qovcSiVld41ZqAxN+y4=";
 
             subPackages = [ "cmd/ign" ];
 


### PR DESCRIPTION
## Summary

This PR adds Nix build verification to the CI pipeline and fixes the inconsistent vendoring issue that was causing build failures. The changes ensure that both Go-based and Nix-based builds are validated in CI, providing comprehensive build verification across different build systems.

## Changes

- Added new `nix-build` job to `.github/workflows/ci.yml` that installs Nix with flakes support and verifies the build
- Updated `vendorHash` in `flake.nix` from `sha256-7K17JaXFsjf163g5PXCb5ng2gYdotnZ2IDKk8KFjNj0=` to `sha256-esmcKwW2KbmEXIukBKUZgN32qovcSiVld41ZqAxN+y4=` to resolve vendoring inconsistency
- Added `/vendor/` directory to `.gitignore` to prevent tracking of Go vendor dependencies

## Changed Files

| File                       | Additions | Deletions | Change Summary                        |
| -------------------------- | --------- | --------- | ------------------------------------- |
| .github/workflows/ci.yml   | 21        | 0         | Add nix-build job to CI workflow      |
| flake.nix                  | 1         | 1         | Update vendorHash for dependency consistency |
| .gitignore                 | 1         | 0         | Add vendor directory to gitignore     |

## Technical Details

### Nix Build Job

The new `nix-build` job performs the following steps:

1. Checks out the code
2. Installs Nix using `cachix/install-nix-action@v30` with flakes and nix-command experimental features enabled
3. Runs `nix build` to verify the flake builds successfully
4. Executes `./result/bin/ign --help` to verify the built binary is functional

This ensures that the Nix flake configuration remains valid and the package builds correctly through Nix, complementing the existing Go-based build and test job.

### VendorHash Update

The `vendorHash` in `flake.nix` was updated to fix the "inconsistent vendoring" error that occurs when Nix's vendored Go dependencies don't match the expected hash. This typically happens after dependency updates or when vendoring state changes. The new hash was computed by Nix during a local build attempt and ensures reproducible builds.

### Build System Coverage

With this change, CI now validates builds through both:
- **Go toolchain** (existing `build-and-test` job): Traditional Go build, test, and coverage reporting
- **Nix flakes** (new `nix-build` job): Reproducible Nix-based builds with vendored dependencies

## Related Issues/PRs



---

## Additional Notes

<!-- You can edit this section freely from the web interface -->
<!-- This section will be preserved when running /gen-pr -->