### PR TITLE
Review fixes for PR #24: Documentation and cross-file consistency

### DIFF
--- a/internal/app/check.go
+++ b/internal/app/check.go
@@ -119,8 +119,9 @@ func checkDirectory(ctx context.Context, p parser.Parser, dirPath string, recurs
 	for _, entry := range entries {
 		fullPath := filepath.Join(dirPath, entry.Name())
 
-		// Skip hidden files and directories
-		if strings.HasPrefix(entry.Name(), ".") {
+		// Skip .git directory (version control metadata)
+		// Other dotfiles like .claude/, .gitignore, .envrc should be included
+		if entry.Name() == ".git" {
 			continue
 		}
 

--- a/internal/app/template_update.go
+++ b/internal/app/template_update.go
@@ -135,6 +135,9 @@ func UpdateTemplate(ctx context.Context, opts UpdateTemplateOptions) (*UpdateTem
 }
 
 // scanTemplateFiles recursively scans files for variable directives.
+// Includes all files and dotfiles (e.g., .gitignore, .envrc, .claude/) except:
+//   - .git directory (version control metadata)
+//   - ign-template.json (template config file itself)
 func scanTemplateFiles(ctx context.Context, dirPath string, recursive bool, result *UpdateTemplateResult) error {
 	entries, err := os.ReadDir(dirPath)
 	if err != nil {
@@ -463,7 +466,9 @@ func updateIgnJson(path string, result *UpdateTemplateResult, existing *model.Ig
 
 // CalculateTemplateHashFromDir calculates SHA256 hash of all template files in a directory.
 // Files are sorted by path to ensure deterministic hash generation.
-// Excludes ign-template.json itself from the hash calculation.
+//
+// Included: All files and dotfiles (e.g., .gitignore, .envrc, .claude/)
+// Excluded: .git directory (version control metadata) and ign-template.json (config file)
 func CalculateTemplateHashFromDir(dirPath string) (string, error) {
 	var filePaths []string
 


### PR DESCRIPTION
## Summary

This PR addresses review findings from PR #24 (Fix dotfile inclusion in template scanning and hash calculation).

### Review Target Comments

- https://github.com/tacogips/ign/pull/24#discussion_r2643516258
- https://github.com/tacogips/ign/pull/24#discussion_r2643516766
- https://github.com/tacogips/ign/pull/24#discussion_r2643518374

## Changes Made

### Documentation Enhancements
- Enhanced `CalculateTemplateHashFromDir` function documentation to explicitly state which files are included/excluded in hash calculation
- Enhanced `scanTemplateFiles` function documentation to clarify file filtering logic
- Both functions now clearly document that dotfiles (e.g., `.gitignore`, `.envrc`, `.claude/`) are included while only `.git` directory is excluded

### Cross-File Consistency Fix
- Fixed `internal/app/check.go` to match the dotfile filtering behavior of `template_update.go`
- Changed from blanket dotfile exclusion to only exclude `.git` directory
- This ensures consistent behavior between `ign update` and `ign check` commands
- Added comprehensive test case to verify dotfiles are checked while `.git` is excluded

## Changed Files

| File | Additions | Deletions | Change Summary |
| ---- | --------- | --------- | -------------- |
| internal/app/template_update.go | 7 | 1 | Enhanced documentation |
| internal/app/check.go | 3 | 2 | Fixed dotfile filtering consistency |
| internal/app/check_test.go | 43 | 0 | Added dotfile inclusion test |

## Test Results

- Compilation: OK - All packages build successfully
- Tests: OK - All tests pass (including new dotfile test)
- go vet: OK - No issues detected
- gofmt: OK - All files properly formatted

## Related PR

Original PR: https://github.com/tacogips/ign/pull/24

## Review Summary

**Total Issues Fixed: 3**

### By Severity:
- Medium: 1 (Cross-file consistency)
- Low: 2 (Documentation improvements)

All review comments have been addressed and fixes have been implemented with appropriate test coverage.