### PR TITLE
fix: add type annotation validation to template check command

### DIFF
--- a/internal/template/parser/parser.go
+++ b/internal/template/parser/parser.go
@@ -360,6 +360,13 @@ func (p *DefaultParser) Validate(ctx context.Context, input []byte) error {
 					"variable name is empty",
 					match.RawText)
 			}
+			// Validate variable syntax including type annotation
+			_, _, _, _, err := parseVarSyntax(match.Args)
+			if err != nil {
+				return newParseErrorWithDirective(InvalidDirectiveSyntax,
+					err.Error(),
+					match.RawText)
+			}
 		case DirectiveComment:
 			// @ign-comment: can have any content (including empty) - it's a template comment
 			// Validation of line positioning is done during processing

--- a/internal/template/parser/parser_test.go
+++ b/internal/template/parser/parser_test.go
@@ -398,6 +398,21 @@ func TestValidate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "valid template with type annotation",
+			input:   "@ign-var:name:string@ and @ign-var:count:int@",
+			wantErr: false,
+		},
+		{
+			name:    "valid template with default value",
+			input:   "@ign-var:name=default@ and @ign-var:desc=A description@",
+			wantErr: false,
+		},
+		{
+			name:    "valid template with type and default",
+			input:   "@ign-var:name:string=default@",
+			wantErr: false,
+		},
+		{
 			name:    "unknown directive",
 			input:   "@ign-loop:items@",
 			wantErr: true,
@@ -410,6 +425,21 @@ func TestValidate(t *testing.T) {
 		{
 			name:    "unclosed if block",
 			input:   "@ign-if:test@content",
+			wantErr: true,
+		},
+		{
+			name:    "invalid type annotation - url as type",
+			input:   "@ign-var:REPOSITORY:https://github.com/user/repo@",
+			wantErr: true,
+		},
+		{
+			name:    "invalid type annotation - sentence as type",
+			input:   "@ign-var:DESCRIPTION:A TypeScript project@",
+			wantErr: true,
+		},
+		{
+			name:    "invalid type annotation - version as type",
+			input:   "@ign-var:VERSION:0.1.0@",
 			wantErr: true,
 		},
 	}


### PR DESCRIPTION
## Summary

Add validation for type annotations in `@ign-var` directives during template validation. Previously, invalid type annotations (e.g., `@ign-var:DESCRIPTION:A TypeScript project@`) would pass validation because the type field was not being checked. Now the `Validate` function calls `parseVarSyntax` to ensure type annotations are valid (`string`, `int`, or `bool`).

## Changes

- Add `parseVarSyntax` call in `Validate()` function to validate type annotations for `DirectiveVar` case
- Add 6 test cases covering:
  - Valid type annotations (with type, with default, with both)
  - Invalid type annotations (URL, sentence, version number as types)

## Changed Files

| File | Additions | Deletions | Change Summary |
| ---- | --------- | --------- | -------------- |
| internal/template/parser/parser.go | 7 | 0 | Add type annotation validation in Validate() |
| internal/template/parser/parser_test.go | 30 | 0 | Add test cases for type annotation validation |

## Technical Details

- The fix reuses the existing `parseVarSyntax` function which already enforces type validation
- Invalid types now generate a `InvalidDirectiveSyntax` error with a descriptive message
- No breaking changes - valid templates continue to work as before
- Error messages clearly indicate the invalid type annotation issue

**Problem addressed**: Malformed variable directives like `@ign-var:REPOSITORY:https://github.com/user/repo@` would incorrectly parse the URL as a type instead of failing validation. This could lead to confusing runtime errors instead of clear validation errors at check time.

## Related Issues/PRs

None

---

## Additional Notes

<!-- You can edit this section freely from the web interface -->
<!-- This section will be preserved when running /gen-pr -->

Add your additional notes here