### PR TITLE
fix: handle symlinks to directories in file traversal functions

### DIFF
--- a/internal/template/provider/github.go
+++ b/internal/template/provider/github.go
@@ -379,11 +379,40 @@ func (p *GitHubProvider) collectFiles(templateRoot string) ([]model.TemplateFile
 
 	err := filepath.Walk(templateRoot, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
+			// Handle errors from Walk (e.g., broken symlinks encountered by Lstat).
+			// If the entry is a broken symlink, skip it gracefully instead of failing.
+			if os.IsNotExist(err) {
+				debug.Debug("[github] Skipping broken symlink: %s", path)
+				return nil
+			}
 			return err
 		}
 
 		// Skip directories
 		if info.IsDir() {
+			return nil
+		}
+
+		// Handle symlinks: filepath.Walk uses os.Lstat, so symlinks appear as
+		// non-directory, non-regular entries. Resolve to determine behavior.
+		if info.Mode()&os.ModeSymlink != 0 {
+			resolved, err := os.Stat(path)
+			if err != nil {
+				// Broken/dangling symlink - skip gracefully
+				debug.Debug("[github] Skipping broken symlink: %s", path)
+				return nil
+			}
+			if resolved.IsDir() {
+				// Symlink to directory - skip (Walk does not descend into symlinked dirs)
+				debug.Debug("[github] Skipping symlink to directory: %s", path)
+				return nil
+			}
+			// Symlink to regular file - fall through to collect it
+		}
+
+		// Skip non-regular, non-symlink files (devices, sockets, named pipes, etc.)
+		if info.Mode()&os.ModeSymlink == 0 && !info.Mode().IsRegular() {
+			debug.Debug("[github] Skipping non-regular file: %s", path)
 			return nil
 		}
 
@@ -398,7 +427,7 @@ func (p *GitHubProvider) collectFiles(templateRoot string) ([]model.TemplateFile
 			return fmt.Errorf("failed to get relative path: %w", err)
 		}
 
-		// Read file content
+		// Read file content (use os.ReadFile which follows symlinks)
 		content, err := os.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("failed to read file %s: %w", relPath, err)


### PR DESCRIPTION
## Summary

Fix all file traversal functions (`scanTemplateFilesRecursive`, `CalculateTemplateHashFromDir`, and `collectFiles` in both local and GitHub providers) to properly handle symlinks to directories, dangling symlinks, and non-regular files. Previously, `filepath.Walk` (which uses `os.Lstat`) would not recognize symlinks to directories as directories, causing `os.ReadFile` to fail with "is a directory" errors.

## Changes

- Add symlink resolution via `os.Stat` in `scanTemplateFilesRecursive` (`internal/app/template_update.go`) to recurse into symlinked directories and skip dangling symlinks
- Add symlink resolution in `CalculateTemplateHashFromDir` (`internal/app/template_update.go`) to skip symlinks-to-directories during hash walks, plus a defensive check before `ReadFile`
- Add symlink handling and broken symlink error recovery in `collectFiles` for both `LocalProvider` (`internal/template/provider/local.go`) and `GitHubProvider` (`internal/template/provider/github.go`)
- Add non-regular file skipping (devices, sockets, named pipes) across all four traversal functions
- Add new test cases for symlink-to-directory and dangling symlink handling in `CalculateTemplateHashFromDir` tests (`internal/app/template_update_test.go`)
- Add `TestScanTemplateFiles_SymlinkHandling` test suite for scan-level symlink behavior (`internal/app/template_update_test.go`)
- Update `TestCollectFiles_SymlinkToDirectory` and `TestCollectFiles_DanglingSymlink` to validate correct behavior (success) instead of documenting broken behavior (expected errors) (`internal/template/provider/local_test.go`)

## Changed Files

| File | Additions | Deletions | Change Summary |
| --- | --- | --- | --- |
| internal/app/template_update_test.go | 127 | 0 | Add symlink handling tests for scan and hash |
| internal/app/template_update.go | 62 | 0 | Add symlink resolution in scan and hash functions |
| internal/template/provider/local_test.go | 51 | 27 | Update symlink tests to expect success |
| internal/template/provider/github.go | 30 | 1 | Add symlink handling in GitHub collectFiles |
| internal/template/provider/local.go | 30 | 1 | Add symlink handling in local collectFiles |

## Technical Details

- **Root cause**: `filepath.Walk` uses `os.Lstat` internally, so symlinks to directories have `info.IsDir() == false`. The code then attempted `os.ReadFile` on a directory path, which fails with "is a directory" error.
- **Fix pattern**: Before processing a file entry, check for `os.ModeSymlink` bit. If set, call `os.Stat` to follow the symlink and determine the real target type. Symlinks to directories are either recursed into (scan) or skipped (hash/collect). Symlinks to regular files fall through to normal processing. Dangling symlinks are skipped with debug logging.
- **Defensive guard**: `CalculateTemplateHashFromDir` adds an extra `os.Stat` check before `ReadFile` to guard against edge cases where a symlink-to-directory might slip past the Walk callback.
- **Non-regular file handling**: Added filtering for devices, sockets, named pipes, and other non-regular file types across all traversal functions.

## Related Issues/PRs

- https://github.com/tacogips/ign/issues/31

---

## Additional Notes

<!-- You can edit this section freely from the web interface -->
<!-- This section will be preserved when running /gen-pr -->

Add your additional notes here.