### PR TITLE
feat: add non-interactive template variable options

### DIFF
--- a/.riela/workflows/ign-variable-options/nodes/node-intake-or-plan.json
+++ b/.riela/workflows/ign-variable-options/nodes/node-intake-or-plan.json
@@ -1,0 +1,8 @@
+{
+  "id": "intake-or-plan",
+  "description": "Plan non-interactive variable support for ign commands.",
+  "executionBackend": "codex-agent",
+  "model": "gpt-5.5",
+  "promptTemplateFile": "prompts/intake-or-plan.md",
+  "variables": {}
+}

--- a/.riela/workflows/ign-variable-options/nodes/node-review.json
+++ b/.riela/workflows/ign-variable-options/nodes/node-review.json
@@ -1,0 +1,8 @@
+{
+  "id": "review",
+  "description": "Review non-interactive variable support changes.",
+  "executionBackend": "codex-agent",
+  "model": "gpt-5.5",
+  "promptTemplateFile": "prompts/review.md",
+  "variables": {}
+}

--- a/.riela/workflows/ign-variable-options/nodes/node-work.json
+++ b/.riela/workflows/ign-variable-options/nodes/node-work.json
@@ -1,0 +1,8 @@
+{
+  "id": "work",
+  "description": "Implement non-interactive variable support for ign commands.",
+  "executionBackend": "codex-agent",
+  "model": "gpt-5.5",
+  "promptTemplateFile": "prompts/work.md",
+  "variables": {}
+}

--- a/.riela/workflows/ign-variable-options/nodes/node-workflow-output.json
+++ b/.riela/workflows/ign-variable-options/nodes/node-workflow-output.json
@@ -1,0 +1,8 @@
+{
+  "id": "workflow-output",
+  "description": "Summarize non-interactive variable support workflow outcome.",
+  "executionBackend": "codex-agent",
+  "model": "gpt-5.5",
+  "promptTemplateFile": "prompts/workflow-output.md",
+  "variables": {}
+}

--- a/.riela/workflows/ign-variable-options/prompts/intake-or-plan.md
+++ b/.riela/workflows/ign-variable-options/prompts/intake-or-plan.md
@@ -1,0 +1,30 @@
+# Intake And Plan
+
+You are working in the `ign` repository.
+
+Requested work:
+
+```text
+{{workflowInput.requestedWork}}
+```
+
+Acceptance criteria:
+
+```json
+{{workflowInput.acceptanceCriteria}}
+```
+
+Constraints:
+
+```json
+{{workflowInput.constraints}}
+```
+
+Inspect the current `ign init` and `ign checkout` behavior. Determine whether non-interactive variable passing already exists. If it does not, produce a concise design and implementation plan that fits the existing Go CLI architecture, test layout, and documentation style.
+
+Return:
+
+- current behavior evidence
+- target CLI surface
+- files likely to change
+- verification commands to run

--- a/.riela/workflows/ign-variable-options/prompts/review.md
+++ b/.riela/workflows/ign-variable-options/prompts/review.md
@@ -1,0 +1,14 @@
+# Review
+
+Review the repository after the implementation step.
+
+Check:
+
+- CLI flags are wired to both `init` and `checkout`.
+- Supplied variables are applied before prompting so non-interactive runs do not ask for provided values.
+- Existing interactive behavior is not broken.
+- Tests are focused and cover success and error paths.
+- Documentation is accurate and uses repository-relative examples only.
+- Verification commands have been run, or failures are clearly explained.
+
+If issues remain, state concrete fixes.

--- a/.riela/workflows/ign-variable-options/prompts/work.md
+++ b/.riela/workflows/ign-variable-options/prompts/work.md
@@ -1,0 +1,21 @@
+# Implement
+
+You are working in the `ign` repository.
+
+Requested work:
+
+```text
+{{workflowInput.requestedWork}}
+```
+
+Implement the plan from the prior step. The required end state is:
+
+- `ign init` can receive template variables non-interactively through CLI options.
+- `ign checkout` can receive template variables non-interactively through CLI options.
+- Interactive prompts remain available when required variables are not supplied.
+- Repeated variable options and key-value input should be supported using existing CLI conventions where possible.
+- Validation rejects malformed variable assignments.
+- Tests cover both commands, repeated values, prompt fallback, and malformed values.
+- User-facing documentation explains the new non-interactive usage.
+
+Follow Go conventions, run `gofmt`, and preserve unrelated worktree changes.

--- a/.riela/workflows/ign-variable-options/prompts/workflow-output.md
+++ b/.riela/workflows/ign-variable-options/prompts/workflow-output.md
@@ -1,0 +1,11 @@
+# Workflow Output
+
+Summarize the workflow result for the user.
+
+Include:
+
+- whether the requested feature already existed or was implemented
+- workflow id and path
+- changed files
+- verification commands and outcomes
+- remaining risks or follow-up work

--- a/.riela/workflows/ign-variable-options/workflow.json
+++ b/.riela/workflows/ign-variable-options/workflow.json
@@ -1,0 +1,68 @@
+{
+  "workflowId": "ign-variable-options",
+  "description": "Design, implement, review, and document non-interactive variable passing for ign init and ign checkout.",
+  "defaults": {
+    "maxLoopIterations": 4,
+    "nodeTimeoutMs": 600000
+  },
+  "entryStepId": "intake-or-plan",
+  "nodes": [
+    {
+      "id": "intake-or-plan",
+      "nodeFile": "nodes/node-intake-or-plan.json"
+    },
+    {
+      "id": "work",
+      "nodeFile": "nodes/node-work.json"
+    },
+    {
+      "id": "review",
+      "nodeFile": "nodes/node-review.json"
+    },
+    {
+      "id": "workflow-output",
+      "nodeFile": "nodes/node-workflow-output.json"
+    }
+  ],
+  "steps": [
+    {
+      "id": "intake-or-plan",
+      "nodeId": "intake-or-plan",
+      "role": "worker",
+      "description": "Inspect current behavior and produce an implementation plan.",
+      "transitions": [
+        {
+          "toStepId": "work"
+        }
+      ]
+    },
+    {
+      "id": "work",
+      "nodeId": "work",
+      "role": "worker",
+      "description": "Implement the requested CLI variable options and documentation.",
+      "transitions": [
+        {
+          "toStepId": "review"
+        }
+      ]
+    },
+    {
+      "id": "review",
+      "nodeId": "review",
+      "role": "worker",
+      "description": "Review implementation quality and verification coverage.",
+      "transitions": [
+        {
+          "toStepId": "workflow-output"
+        }
+      ]
+    },
+    {
+      "id": "workflow-output",
+      "nodeId": "workflow-output",
+      "role": "worker",
+      "description": "Summarize outcome, changed files, and remaining risks."
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Initialize configuration from a template source.
 ign init github.com/owner/repo
 ign init github.com/owner/repo/path/to/template
 ign init github.com/owner/repo --ref v1.0.0
+ign init github.com/owner/repo --var app_name=my-app --var port=8080
 
 # From local path
 ign init ./my-local-template
@@ -58,6 +59,7 @@ ign init /absolute/path/to/template
 |------|-------|-------------|
 | `--ref` | `-r` | Git branch, tag, or commit SHA (default: main) |
 | `--force` | `-f` | Backup existing config and reinitialize |
+| `--var` | `-V` | Set a template variable as `key=value` (repeatable) |
 
 **Behavior:**
 
@@ -69,6 +71,9 @@ ign init /absolute/path/to/template
 
 **Backup naming:** When `--force` is used, existing `ign-var.json` is backed up as `ign-var.json.bk1`, `ign-var.json.bk2`, etc.
 
+Variables supplied with `--var` are written to `.ign/ign-var.json`. Missing
+variables are still prompted interactively.
+
 ```bash
 # Force reinitialize with backup
 ign init github.com/owner/repo --force
@@ -79,19 +84,22 @@ ign init github.com/owner/repo --force
 #   ign-var.json.bk1   <- Previous config
 ```
 
-### `ign checkout <path>`
+### `ign checkout <url-or-path> [output-path]`
 
-Generate project files to the specified path using existing `.ign/`.
+Initialize configuration and generate project files from a template in one step.
 
 ```bash
-ign checkout .              # Generate to current directory
-ign checkout ./my-project   # Generate to specific directory
-ign checkout sub_dir        # Generate to subdirectory
-ign checkout . --dry-run    # Preview without writing files
-ign checkout . --verbose    # Show detailed processing info
+ign checkout github.com/owner/repo              # Generate to current directory
+ign checkout github.com/owner/repo ./my-project # Generate to specific directory
+ign checkout ./my-local-template ./my-project   # Generate from local template
+ign checkout github.com/owner/repo --dry-run    # Preview without writing files
+ign checkout github.com/owner/repo --verbose    # Show detailed processing info
+ign checkout github.com/owner/repo --var app_name=my-app --var port=8080
 ```
 
-**Requires:** `.ign/ign-var.json` must exist (run `ign init` first).
+If `.ign/` already exists, checkout does nothing unless `--force` is used.
+Variables supplied with `--var` are used for generation and saved to
+`.ign/ign-var.json`. Missing variables are still prompted interactively.
 
 **Flags:**
 
@@ -100,6 +108,7 @@ ign checkout . --verbose    # Show detailed processing info
 | `--force` | `-f` | Overwrite existing files |
 | `--dry-run` | `-d` | Show what would be generated without writing |
 | `--verbose` | `-v` | Show detailed processing information |
+| `--var` | `-V` | Set a template variable as `key=value` (repeatable, one-shot checkout) |
 
 **File handling:**
 

--- a/design-docs/specs/command.md
+++ b/design-docs/specs/command.md
@@ -1,0 +1,43 @@
+# Command Interface
+
+## Non-Interactive Template Variables
+
+`ign init` and one-shot `ign checkout <url-or-path> [output-path]` support a
+repeatable variable option:
+
+```bash
+ign init ./template --var project_name=my-app --var port=8080
+ign checkout ./template ./out --var project_name=my-app --var port=8080
+```
+
+The short form is `-V`:
+
+```bash
+ign checkout ./template ./out -V project_name=my-app -V enable_feature=true
+```
+
+### Design
+
+- The option surface is `--var key=value`, repeatable with last value winning.
+- Values are parsed after template preparation, so assignments can be validated
+  against `ign-template.json` variable definitions.
+- Unknown variable names fail early to catch typos.
+- If variable parsing fails after template preparation and the command created
+  `.ign/`, the new `.ign/` directory is removed before returning the error.
+- String values preserve everything after the first `=`.
+- `int`, `number`, and `bool` values are converted to their configured Go types.
+- String patterns and numeric min/max constraints are enforced for supplied
+  values.
+- Provided variables are passed into the prompt layer before interactive
+  collection. Variables supplied by option are not prompted; missing variables
+  keep the existing interactive fallback.
+- `ign init` saves supplied values into `.ign/ign-var.json` without generating
+  project files.
+- `ign checkout` uses supplied values for both saved `.ign/ign-var.json` and
+  project generation.
+
+### Current Behavior Finding
+
+Before this design, the CLI had no registered `ign init` command and one-shot
+`ign checkout` always called the interactive prompt helper for all template
+variables. There was no CLI option for non-interactive variable assignment.

--- a/design-docs/specs/command.md
+++ b/design-docs/specs/command.md
@@ -22,8 +22,10 @@ ign checkout ./template ./out -V project_name=my-app -V enable_feature=true
 - Values are parsed after template preparation, so assignments can be validated
   against `ign-template.json` variable definitions.
 - Unknown variable names fail early to catch typos.
-- If variable parsing fails after template preparation and the command created
-  `.ign/`, the new `.ign/` directory is removed before returning the error.
+- `.ign` creation and force-mode backup are deferred until after variable
+  parsing and prompting succeed, so invalid non-interactive variables do not
+  modify existing configuration.
+- `ign checkout --dry-run` does not create or back up `.ign`.
 - String values preserve everything after the first `=`.
 - `int`, `number`, and `bool` values are converted to their configured Go types.
 - String patterns and numeric min/max constraints are enforced for supplied

--- a/docs/progress/non-interactive-template-variables.md
+++ b/docs/progress/non-interactive-template-variables.md
@@ -14,7 +14,8 @@
 - [x] Added registered `ign init` command with `--var` support (`internal/cli/init.go`, `internal/cli/root.go`)
 - [x] Added app-layer init completion that stores provided variables without generation (`internal/app/config_init.go`, `internal/app/workflows.go`)
 - [x] Added unit coverage for parsing, malformed assignments, no-prompt supplied values, and init variable map overlay (`internal/cli/variables_test.go`, `internal/app/app_test.go`)
-- [x] Added cleanup for newly-created `.ign/` when post-template variable parsing fails (`internal/cli/variables.go`)
+- [x] Deferred `.ign` creation/backups until after variable parsing and prompting succeed (`internal/app/checkout.go`, `internal/cli/init.go`, `internal/cli/checkout.go`)
+- [x] Added integration coverage for side-effect-free template preparation (`test/integration/config_init_test.go`)
 - [x] Documented user-facing usage (`README.md`)
 
 ## Remaining

--- a/docs/progress/non-interactive-template-variables.md
+++ b/docs/progress/non-interactive-template-variables.md
@@ -1,0 +1,36 @@
+# Non-Interactive Template Variables
+
+**Status**: Completed
+
+## Spec Reference
+
+- `design-docs/specs/command.md` Section "Non-Interactive Template Variables"
+
+## Implemented
+
+- [x] Added repeatable `--var` / `-V` parsing for `key=value` template variables (`internal/cli/variables.go`)
+- [x] Added prompt fallback that skips variables already supplied by option (`internal/cli/prompt.go`)
+- [x] Added `--var` support to one-shot checkout (`internal/cli/checkout.go`)
+- [x] Added registered `ign init` command with `--var` support (`internal/cli/init.go`, `internal/cli/root.go`)
+- [x] Added app-layer init completion that stores provided variables without generation (`internal/app/config_init.go`, `internal/app/workflows.go`)
+- [x] Added unit coverage for parsing, malformed assignments, no-prompt supplied values, and init variable map overlay (`internal/cli/variables_test.go`, `internal/app/app_test.go`)
+- [x] Added cleanup for newly-created `.ign/` when post-template variable parsing fails (`internal/cli/variables.go`)
+- [x] Documented user-facing usage (`README.md`)
+
+## Remaining
+
+- [ ] None
+
+## Design Decisions
+
+- Use repeatable `--var key=value` instead of JSON input to match common CLI
+  conventions and keep simple shell usage readable.
+- Reject unknown variables after template preparation so typos fail before any
+  generation happens.
+- Preserve interactive prompts for missing variables to avoid breaking the
+  existing guided workflow.
+
+## Notes
+
+- `ign init` is now registered in the CLI because the app layer and README
+  already described it, but the command was not wired into `rootCmd`.

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -134,6 +134,41 @@ func TestCreateEmptyVariablesMap(t *testing.T) {
 	}
 }
 
+func TestCreateVariablesMap_ProvidedValues(t *testing.T) {
+	ignJson := &model.IgnJson{
+		Name:    "test-template",
+		Version: "1.0.0",
+		Variables: map[string]model.VarDef{
+			"project_name": {
+				Type:    model.VarTypeString,
+				Default: "default-name",
+			},
+			"port": {
+				Type:    model.VarTypeInt,
+				Default: 8080,
+			},
+			"enable_tls": {
+				Type: model.VarTypeBool,
+			},
+		},
+	}
+
+	vars := CreateVariablesMap(ignJson, map[string]interface{}{
+		"project_name": "provided-name",
+		"enable_tls":   true,
+	})
+
+	if got := vars["project_name"]; got != "provided-name" {
+		t.Fatalf("project_name = %v, want provided-name", got)
+	}
+	if got := vars["port"]; got != 8080 {
+		t.Fatalf("port = %v, want default 8080", got)
+	}
+	if got := vars["enable_tls"]; got != true {
+		t.Fatalf("enable_tls = %v, want true", got)
+	}
+}
+
 func TestCountVariablesByType_NilIgnJSON(t *testing.T) {
 	stringCount, intCount, boolCount := CountVariablesByType(nil)
 	if stringCount != 0 || intCount != 0 || boolCount != 0 {

--- a/internal/app/checkout.go
+++ b/internal/app/checkout.go
@@ -27,6 +27,8 @@ type PrepareCheckoutOptions struct {
 	ConfigExists bool
 	// GitHubToken is the GitHub personal access token (optional).
 	GitHubToken string
+	// SkipConfigSetup skips .ign creation/backup during preparation.
+	SkipConfigSetup bool
 }
 
 // PrepareCheckoutResult contains the result of checkout preparation.
@@ -193,55 +195,10 @@ func PrepareCheckout(ctx context.Context, opts PrepareCheckoutOptions) (*Prepare
 	debug.DebugValue("[app] Template name", template.Config.Name)
 	debug.DebugValue("[app] Template version", template.Config.Version)
 
-	// Handle config directory
-	if opts.ConfigExists {
-		// Directory exists and Force is true (checked in CLI layer)
-		debug.Debug("[app] Config directory exists, Force mode - backing up")
-
-		// Backup existing ign.json if it exists
-		ignConfigPath := filepath.Join(configDir, model.IgnProjectConfigFile)
-		if _, err := os.Stat(ignConfigPath); err == nil {
-			backupNum, err := findNextBackupNumber(configDir, model.IgnProjectConfigFile)
-			if err != nil {
-				return nil, NewCheckoutError(err.Error(), nil)
-			}
-			backupPath := filepath.Join(configDir, fmt.Sprintf("%s.bk%d", model.IgnProjectConfigFile, backupNum))
-			debug.Debug("[app] Backing up existing ign.json to: %s", backupPath)
-			if err := os.Rename(ignConfigPath, backupPath); err != nil {
-				debug.Debug("[app] Failed to backup existing ign.json: %v", err)
-				return nil, NewCheckoutError("failed to backup existing ign.json", err)
-			}
-			debug.Debug("[app] Existing ign.json backed up successfully")
+	if !opts.SkipConfigSetup {
+		if err := PrepareCheckoutConfigDir(opts.ConfigExists); err != nil {
+			return nil, err
 		}
-
-		// Backup existing ign-var.json if it exists
-		ignVarPath := filepath.Join(configDir, model.IgnVarFile)
-		if _, err := os.Stat(ignVarPath); err == nil {
-			backupNum, err := findNextBackupNumber(configDir, model.IgnVarFile)
-			if err != nil {
-				return nil, NewCheckoutError(err.Error(), nil)
-			}
-			backupPath := filepath.Join(configDir, fmt.Sprintf("%s.bk%d", model.IgnVarFile, backupNum))
-			debug.Debug("[app] Backing up existing ign-var.json to: %s", backupPath)
-			if err := os.Rename(ignVarPath, backupPath); err != nil {
-				debug.Debug("[app] Failed to backup existing ign-var.json: %v", err)
-				return nil, NewCheckoutError("failed to backup existing ign-var.json", err)
-			}
-			debug.Debug("[app] Existing ign-var.json backed up successfully")
-		}
-
-		if err := backupManifestIfExists(); err != nil {
-			debug.Debug("[app] Failed to backup existing ign-files.json: %v", err)
-			return nil, NewCheckoutError("failed to backup existing ign-files.json", err)
-		}
-	} else {
-		// Create config directory
-		debug.Debug("[app] Creating config directory: %s", configDir)
-		if err := os.MkdirAll(configDir, 0755); err != nil {
-			debug.Debug("[app] Failed to create config directory: %v", err)
-			return nil, NewCheckoutError("failed to create config directory", err)
-		}
-		debug.Debug("[app] Config directory created successfully")
 	}
 
 	debug.Debug("[app] PrepareCheckout completed successfully")
@@ -251,6 +208,65 @@ func PrepareCheckout(ctx context.Context, opts PrepareCheckoutOptions) (*Prepare
 		TemplateRef:   templateRef,
 		NormalizedURL: normalizedURL,
 	}, nil
+}
+
+// PrepareCheckoutConfigDir creates or backs up .ign before writing checkout/init files.
+func PrepareCheckoutConfigDir(configExists bool) error {
+	configDir := model.IgnConfigDir
+
+	if configExists {
+		// Directory exists and Force is true (checked in CLI layer)
+		debug.Debug("[app] Config directory exists, Force mode - backing up")
+
+		// Backup existing ign.json if it exists
+		ignConfigPath := filepath.Join(configDir, model.IgnProjectConfigFile)
+		if _, err := os.Stat(ignConfigPath); err == nil {
+			backupNum, err := findNextBackupNumber(configDir, model.IgnProjectConfigFile)
+			if err != nil {
+				return NewCheckoutError(err.Error(), nil)
+			}
+			backupPath := filepath.Join(configDir, fmt.Sprintf("%s.bk%d", model.IgnProjectConfigFile, backupNum))
+			debug.Debug("[app] Backing up existing ign.json to: %s", backupPath)
+			if err := os.Rename(ignConfigPath, backupPath); err != nil {
+				debug.Debug("[app] Failed to backup existing ign.json: %v", err)
+				return NewCheckoutError("failed to backup existing ign.json", err)
+			}
+			debug.Debug("[app] Existing ign.json backed up successfully")
+		}
+
+		// Backup existing ign-var.json if it exists
+		ignVarPath := filepath.Join(configDir, model.IgnVarFile)
+		if _, err := os.Stat(ignVarPath); err == nil {
+			backupNum, err := findNextBackupNumber(configDir, model.IgnVarFile)
+			if err != nil {
+				return NewCheckoutError(err.Error(), nil)
+			}
+			backupPath := filepath.Join(configDir, fmt.Sprintf("%s.bk%d", model.IgnVarFile, backupNum))
+			debug.Debug("[app] Backing up existing ign-var.json to: %s", backupPath)
+			if err := os.Rename(ignVarPath, backupPath); err != nil {
+				debug.Debug("[app] Failed to backup existing ign-var.json: %v", err)
+				return NewCheckoutError("failed to backup existing ign-var.json", err)
+			}
+			debug.Debug("[app] Existing ign-var.json backed up successfully")
+		}
+
+		if err := backupManifestIfExists(); err != nil {
+			debug.Debug("[app] Failed to backup existing ign-files.json: %v", err)
+			return NewCheckoutError("failed to backup existing ign-files.json", err)
+		}
+
+		return nil
+	}
+
+	// Create config directory
+	debug.Debug("[app] Creating config directory: %s", configDir)
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		debug.Debug("[app] Failed to create config directory: %v", err)
+		return NewCheckoutError("failed to create config directory", err)
+	}
+	debug.Debug("[app] Config directory created successfully")
+
+	return nil
 }
 
 // CompleteCheckout completes checkout by saving configuration and generating files.

--- a/internal/app/config_init.go
+++ b/internal/app/config_init.go
@@ -25,6 +25,18 @@ type InitOptions struct {
 	Config string
 	// GitHubToken is the GitHub personal access token (optional).
 	GitHubToken string
+	// Variables contains user-provided variable values.
+	Variables map[string]interface{}
+}
+
+// CompleteInitOptions contains options for saving initialized configuration.
+type CompleteInitOptions struct {
+	// PrepareResult is the result from PrepareCheckout.
+	PrepareResult *PrepareCheckoutResult
+	// Variables contains user-provided variable values.
+	Variables map[string]interface{}
+	// GeneratedBy identifies the command that generated metadata.
+	GeneratedBy string
 }
 
 // Init initializes configuration from a template.
@@ -66,19 +78,33 @@ func Init(ctx context.Context, opts InitOptions) error {
 		return err
 	}
 
-	// Get hash from template's ign-template.json
-	// The hash must be present (calculated by 'ign template update' on the template side)
+	return CompleteInit(ctx, CompleteInitOptions{
+		PrepareResult: prepResult,
+		Variables:     opts.Variables,
+		GeneratedBy:   "ign init",
+	})
+}
+
+// CompleteInit saves initialization configuration after template preparation.
+func CompleteInit(ctx context.Context, opts CompleteInitOptions) error {
+	_ = ctx
+
+	configDir := model.IgnConfigDir
+	prepResult := opts.PrepareResult
+	if prepResult == nil {
+		return NewValidationError("prepare result cannot be nil", nil)
+	}
+
 	templateHash := prepResult.IgnJson.Hash
 	debug.DebugValue("[app] Template hash from ign-template.json", templateHash)
 
-	// Validate hash is present
-	if templateHash == "" {
-		debug.Debug("[app] Template hash is missing in ign-template.json")
-		return NewCheckoutError(
-			"template is missing hash in ign-template.json.\n"+
-				"The template author needs to run 'ign template update' to generate the hash.",
-			nil,
-		)
+	if err := validateTemplateHash(templateHash); err != nil {
+		return err
+	}
+
+	generatedBy := opts.GeneratedBy
+	if generatedBy == "" {
+		generatedBy = "ign init"
 	}
 
 	// Save ign.json (template source and hash)
@@ -93,7 +119,7 @@ func Init(ctx context.Context, opts InitOptions) error {
 		Hash: templateHash,
 		Metadata: &model.FileMetadata{
 			GeneratedAt:     time.Now(),
-			GeneratedBy:     "ign init",
+			GeneratedBy:     generatedBy,
 			TemplateName:    prepResult.IgnJson.Name,
 			TemplateVersion: prepResult.IgnJson.Version,
 			IgnVersion:      build.Version(),
@@ -103,7 +129,7 @@ func Init(ctx context.Context, opts InitOptions) error {
 	// Create ign-var.json with empty/default variables (no metadata as it's already in ign.json)
 	debug.Debug("[app] Creating ign-var.json with default variables")
 	ignVarJson := &model.IgnVarJson{
-		Variables: CreateEmptyVariablesMap(prepResult.IgnJson),
+		Variables: CreateVariablesMap(prepResult.IgnJson, opts.Variables),
 	}
 
 	ignVarPath := filepath.Join(configDir, model.IgnVarFile)

--- a/internal/app/workflows.go
+++ b/internal/app/workflows.go
@@ -63,11 +63,20 @@ func ValidateOutputDir(path string) error {
 // CreateEmptyVariablesMap creates an initial variables map from IgnJson variable definitions.
 // Declared defaults are preserved as authored so runtime-only placeholders can be resolved later.
 func CreateEmptyVariablesMap(ignJson *model.IgnJson) map[string]interface{} {
+	return CreateVariablesMap(ignJson, nil)
+}
+
+// CreateVariablesMap creates an initial variables map and overlays provided values.
+func CreateVariablesMap(ignJson *model.IgnJson, providedVars map[string]interface{}) map[string]interface{} {
 	if ignJson == nil {
-		return map[string]interface{}{}
+		vars := make(map[string]interface{}, len(providedVars))
+		for name, value := range providedVars {
+			vars[name] = value
+		}
+		return vars
 	}
 
-	vars := mergeVariableDefaults(ignJson.Variables, nil)
+	vars := mergeVariableDefaults(ignJson.Variables, providedVars)
 
 	for name, varDef := range ignJson.Variables {
 		if _, ok := vars[name]; ok {

--- a/internal/cli/checkout.go
+++ b/internal/cli/checkout.go
@@ -99,11 +99,12 @@ func runCheckout(cmd *cobra.Command, args []string) error {
 
 	// Prepare template and get variable definitions
 	prepResult, err := app.PrepareCheckout(cmd.Context(), app.PrepareCheckoutOptions{
-		URL:          url,
-		Ref:          checkoutRef,
-		Force:        checkoutForce,
-		ConfigExists: configExists,
-		GitHubToken:  githubToken,
+		URL:             url,
+		Ref:             checkoutRef,
+		Force:           checkoutForce,
+		ConfigExists:    configExists,
+		GitHubToken:     githubToken,
+		SkipConfigSetup: true,
 	})
 	if err != nil {
 		printErrorMsg(fmt.Sprintf("Preparation failed: %v", err))
@@ -113,7 +114,6 @@ func runCheckout(cmd *cobra.Command, args []string) error {
 	resolvedIgnJSON := templatedefaults.ResolveIgnJSON(prepResult.IgnJson, outputPath)
 	providedVars, err := ParseVariableAssignments(checkoutVars, resolvedIgnJSON.Variables)
 	if err != nil {
-		cleanupPreparedConfigOnVariableError(configExists)
 		printErrorMsg(fmt.Sprintf("Variable parsing failed: %v", err))
 		return err
 	}
@@ -129,6 +129,10 @@ func runCheckout(cmd *cobra.Command, args []string) error {
 	if checkoutDryRun {
 		printInfo("[DRY RUN] Would generate project from template")
 	} else {
+		if err := app.PrepareCheckoutConfigDir(configExists); err != nil {
+			printErrorMsg(fmt.Sprintf("Checkout failed: %v", err))
+			return err
+		}
 		printInfo("Generating project from template...")
 	}
 

--- a/internal/cli/checkout.go
+++ b/internal/cli/checkout.go
@@ -34,6 +34,7 @@ Examples:
   ign checkout github.com/owner/repo
   ign checkout github.com/owner/repo ./my-project
   ign checkout github.com/owner/repo --ref v1.2.0
+  ign checkout github.com/owner/repo --var project_name=my-app --var port=8080
   ign checkout ./my-local-template ./output
   ign checkout github.com/owner/repo --force
   ign checkout github.com/owner/repo --dry-run`,
@@ -47,6 +48,7 @@ var (
 	checkoutForce   bool
 	checkoutDryRun  bool
 	checkoutVerbose bool
+	checkoutVars    []string
 )
 
 func init() {
@@ -55,10 +57,15 @@ func init() {
 	checkoutCmd.Flags().BoolVarP(&checkoutForce, "force", "f", false, "Backup and reinitialize existing config, overwrite files")
 	checkoutCmd.Flags().BoolVarP(&checkoutDryRun, "dry-run", "d", false, "Show what would be generated without writing files")
 	checkoutCmd.Flags().BoolVarP(&checkoutVerbose, "verbose", "v", false, "Show detailed processing information")
+	checkoutCmd.Flags().StringArrayVarP(&checkoutVars, FlagVar, "V", nil, DescVar)
 }
 
 func runCheckout(cmd *cobra.Command, args []string) error {
 	url := args[0]
+	if err := ValidateVariableAssignmentSyntax(checkoutVars); err != nil {
+		printErrorMsg(fmt.Sprintf("Variable parsing failed: %v", err))
+		return err
+	}
 
 	// Output path defaults to current directory
 	outputPath := "."
@@ -103,8 +110,16 @@ func runCheckout(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Prompt for variables interactively
-	vars, err := PromptForVariables(templatedefaults.ResolveIgnJSON(prepResult.IgnJson, outputPath))
+	resolvedIgnJSON := templatedefaults.ResolveIgnJSON(prepResult.IgnJson, outputPath)
+	providedVars, err := ParseVariableAssignments(checkoutVars, resolvedIgnJSON.Variables)
+	if err != nil {
+		cleanupPreparedConfigOnVariableError(configExists)
+		printErrorMsg(fmt.Sprintf("Variable parsing failed: %v", err))
+		return err
+	}
+
+	// Prompt only for variables that were not supplied by flag.
+	vars, err := PromptForVariablesWithProvided(resolvedIgnJSON, providedVars)
 	if err != nil {
 		printErrorMsg(fmt.Sprintf("Variable collection failed: %v", err))
 		return err

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -21,6 +21,7 @@ const (
 	FlagNoColor   = "no-color"
 	FlagQuiet     = "quiet"
 	FlagDebug     = "debug"
+	FlagVar       = "var"
 
 	// Flag descriptions
 	DescOutput    = "Output directory"
@@ -33,6 +34,7 @@ const (
 	DescNoColor   = "Disable colored output"
 	DescQuiet     = "Suppress output"
 	DescDebug     = "Enable debug logging"
+	DescVar       = "Set a template variable as key=value (repeatable)"
 )
 
 // URL validation patterns

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -1,0 +1,101 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/tacogips/ign/internal/app"
+	templatedefaults "github.com/tacogips/ign/internal/template/defaults"
+)
+
+var (
+	initRef   string
+	initForce bool
+	initVars  []string
+)
+
+var initCmd = &cobra.Command{
+	Use:   "init <url-or-path>",
+	Short: "Initialize ign configuration from a template",
+	Long: `Initialize ign configuration from a template source.
+
+The init command creates .ign/ign.json and .ign/ign-var.json. Template variables
+can be supplied non-interactively with --var key=value. Missing variables are
+prompted interactively.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runInit,
+}
+
+func init() {
+	initCmd.Flags().StringVarP(&initRef, FlagRef, "r", "main", DescRef)
+	initCmd.Flags().BoolVarP(&initForce, FlagForce, "f", false, "Backup existing config and reinitialize")
+	initCmd.Flags().StringArrayVarP(&initVars, FlagVar, "V", nil, DescVar)
+}
+
+func runInit(cmd *cobra.Command, args []string) error {
+	url := args[0]
+	if err := ValidateVariableAssignmentSyntax(initVars); err != nil {
+		printErrorMsg(fmt.Sprintf("Variable parsing failed: %v", err))
+		return err
+	}
+
+	configDir := ".ign"
+	configExists := false
+
+	if _, err := os.Stat(configDir); err == nil {
+		configExists = true
+		if !initForce {
+			err := fmt.Errorf("configuration already exists at %s (use --force to reinitialize)", configDir)
+			printErrorMsg(err.Error())
+			return err
+		}
+		printWarning("Force mode enabled - will backup existing configuration")
+	}
+
+	githubToken := getGitHubToken("")
+
+	printInfo(fmt.Sprintf("Template: %s", url))
+	if initRef != "main" {
+		printInfo(fmt.Sprintf("Reference: %s", initRef))
+	}
+
+	prepResult, err := app.PrepareCheckout(cmd.Context(), app.PrepareCheckoutOptions{
+		URL:          url,
+		Ref:          initRef,
+		Force:        initForce,
+		ConfigExists: configExists,
+		GitHubToken:  githubToken,
+	})
+	if err != nil {
+		printErrorMsg(fmt.Sprintf("Initialization failed: %v", err))
+		return err
+	}
+
+	resolvedIgnJSON := templatedefaults.ResolveIgnJSON(prepResult.IgnJson, ".")
+	providedVars, err := ParseVariableAssignments(initVars, resolvedIgnJSON.Variables)
+	if err != nil {
+		cleanupPreparedConfigOnVariableError(configExists)
+		printErrorMsg(fmt.Sprintf("Variable parsing failed: %v", err))
+		return err
+	}
+
+	vars, err := PromptForVariablesWithProvided(resolvedIgnJSON, providedVars)
+	if err != nil {
+		printErrorMsg(fmt.Sprintf("Variable collection failed: %v", err))
+		return err
+	}
+
+	if err := app.CompleteInit(cmd.Context(), app.CompleteInitOptions{
+		PrepareResult: prepResult,
+		Variables:     vars,
+		GeneratedBy:   "ign init",
+	}); err != nil {
+		printErrorMsg(fmt.Sprintf("Initialization failed: %v", err))
+		return err
+	}
+
+	printSuccess("Configuration initialized successfully")
+	printInfo("Configuration saved to: .ign/ign.json, .ign/ign-var.json")
+	return nil
+}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -61,11 +61,12 @@ func runInit(cmd *cobra.Command, args []string) error {
 	}
 
 	prepResult, err := app.PrepareCheckout(cmd.Context(), app.PrepareCheckoutOptions{
-		URL:          url,
-		Ref:          initRef,
-		Force:        initForce,
-		ConfigExists: configExists,
-		GitHubToken:  githubToken,
+		URL:             url,
+		Ref:             initRef,
+		Force:           initForce,
+		ConfigExists:    configExists,
+		GitHubToken:     githubToken,
+		SkipConfigSetup: true,
 	})
 	if err != nil {
 		printErrorMsg(fmt.Sprintf("Initialization failed: %v", err))
@@ -75,7 +76,6 @@ func runInit(cmd *cobra.Command, args []string) error {
 	resolvedIgnJSON := templatedefaults.ResolveIgnJSON(prepResult.IgnJson, ".")
 	providedVars, err := ParseVariableAssignments(initVars, resolvedIgnJSON.Variables)
 	if err != nil {
-		cleanupPreparedConfigOnVariableError(configExists)
 		printErrorMsg(fmt.Sprintf("Variable parsing failed: %v", err))
 		return err
 	}
@@ -83,6 +83,11 @@ func runInit(cmd *cobra.Command, args []string) error {
 	vars, err := PromptForVariablesWithProvided(resolvedIgnJSON, providedVars)
 	if err != nil {
 		printErrorMsg(fmt.Sprintf("Variable collection failed: %v", err))
+		return err
+	}
+
+	if err := app.PrepareCheckoutConfigDir(configExists); err != nil {
+		printErrorMsg(fmt.Sprintf("Initialization failed: %v", err))
 		return err
 	}
 

--- a/internal/cli/prompt.go
+++ b/internal/cli/prompt.go
@@ -13,7 +13,15 @@ import (
 // PromptForVariables interactively prompts the user for variable values.
 // Returns a map of variable names to their values.
 func PromptForVariables(ignJson *model.IgnJson) (map[string]interface{}, error) {
-	vars := make(map[string]interface{})
+	return PromptForVariablesWithProvided(ignJson, nil)
+}
+
+// PromptForVariablesWithProvided prompts for variable values that were not already provided.
+func PromptForVariablesWithProvided(ignJson *model.IgnJson, providedVars map[string]interface{}) (map[string]interface{}, error) {
+	vars := make(map[string]interface{}, len(providedVars))
+	for name, value := range providedVars {
+		vars[name] = value
+	}
 
 	if ignJson == nil {
 		return vars, nil
@@ -30,11 +38,23 @@ func PromptForVariables(ignJson *model.IgnJson) (map[string]interface{}, error) 
 	}
 	sort.Strings(varNames)
 
+	missingVarNames := make([]string, 0, len(varNames))
+	for _, name := range varNames {
+		if _, provided := vars[name]; provided {
+			continue
+		}
+		missingVarNames = append(missingVarNames, name)
+	}
+
+	if len(missingVarNames) == 0 {
+		return vars, nil
+	}
+
 	fmt.Println()
 	fmt.Println("Please provide values for template variables:")
 	fmt.Println()
 
-	for _, name := range varNames {
+	for _, name := range missingVarNames {
 		varDef := ignJson.Variables[name]
 
 		value, err := promptForVariable(name, varDef)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -53,6 +53,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&globalDebug, FlagDebug, false, DescDebug)
 
 	// Add subcommands
+	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(checkoutCmd)
 	rootCmd.AddCommand(updateCmd)
 	rootCmd.AddCommand(rewindCmd)

--- a/internal/cli/variables.go
+++ b/internal/cli/variables.go
@@ -1,0 +1,114 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/tacogips/ign/internal/template/model"
+)
+
+// ParseVariableAssignments parses repeatable key=value CLI variable assignments.
+func ParseVariableAssignments(assignments []string, varDefs map[string]model.VarDef) (map[string]interface{}, error) {
+	if err := ValidateVariableAssignmentSyntax(assignments); err != nil {
+		return nil, err
+	}
+
+	vars := make(map[string]interface{}, len(assignments))
+	for _, assignment := range assignments {
+		name, rawValue, _ := strings.Cut(assignment, "=")
+		name = strings.TrimSpace(name)
+
+		varDef, ok := varDefs[name]
+		if !ok {
+			return nil, fmt.Errorf("unknown template variable %q", name)
+		}
+
+		value, err := parseVariableValue(name, rawValue, varDef)
+		if err != nil {
+			return nil, err
+		}
+		vars[name] = value
+	}
+	return vars, nil
+}
+
+// ValidateVariableAssignmentSyntax validates key=value syntax without template metadata.
+func ValidateVariableAssignmentSyntax(assignments []string) error {
+	for _, assignment := range assignments {
+		name, _, ok := strings.Cut(assignment, "=")
+		if !ok {
+			return fmt.Errorf("invalid variable assignment %q: expected key=value", assignment)
+		}
+		if strings.TrimSpace(name) == "" {
+			return fmt.Errorf("invalid variable assignment %q: variable name cannot be empty", assignment)
+		}
+	}
+	return nil
+}
+
+func cleanupPreparedConfigOnVariableError(configExists bool) {
+	if configExists {
+		return
+	}
+	if err := os.RemoveAll(".ign"); err != nil {
+		printWarning(fmt.Sprintf("Failed to clean up .ign after variable parsing error: %v", err))
+	}
+}
+
+func parseVariableValue(name string, rawValue string, varDef model.VarDef) (interface{}, error) {
+	switch varDef.Type {
+	case model.VarTypeInt:
+		value, err := strconv.Atoi(rawValue)
+		if err != nil {
+			return nil, fmt.Errorf("variable %q must be an integer: %w", name, err)
+		}
+		if err := validateNumericRange(name, float64(value), varDef); err != nil {
+			return nil, err
+		}
+		return value, nil
+	case model.VarTypeNumber:
+		value, err := strconv.ParseFloat(rawValue, 64)
+		if err != nil {
+			return nil, fmt.Errorf("variable %q must be a number: %w", name, err)
+		}
+		if err := validateNumericRange(name, value, varDef); err != nil {
+			return nil, err
+		}
+		return value, nil
+	case model.VarTypeBool:
+		value, err := strconv.ParseBool(rawValue)
+		if err != nil {
+			return nil, fmt.Errorf("variable %q must be a boolean: %w", name, err)
+		}
+		return value, nil
+	case model.VarTypeString, "":
+		if varDef.Required && strings.TrimSpace(rawValue) == "" {
+			return nil, fmt.Errorf("variable %q is required", name)
+		}
+		if varDef.Pattern != "" {
+			matched, err := regexp.MatchString(varDef.Pattern, rawValue)
+			if err != nil {
+				return nil, fmt.Errorf("variable %q has invalid pattern %q: %w", name, varDef.Pattern, err)
+			}
+			if !matched {
+				return nil, fmt.Errorf("variable %q must match pattern: %s", name, varDef.Pattern)
+			}
+		}
+		return rawValue, nil
+	default:
+		return rawValue, nil
+	}
+}
+
+func validateNumericRange(name string, value float64, varDef model.VarDef) error {
+	if varDef.Min != nil && value < *varDef.Min {
+		return fmt.Errorf("variable %q must be >= %v", name, *varDef.Min)
+	}
+	if varDef.Max != nil && value > *varDef.Max {
+		return fmt.Errorf("variable %q must be <= %v", name, *varDef.Max)
+	}
+	return nil
+}

--- a/internal/cli/variables.go
+++ b/internal/cli/variables.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -47,15 +46,6 @@ func ValidateVariableAssignmentSyntax(assignments []string) error {
 		}
 	}
 	return nil
-}
-
-func cleanupPreparedConfigOnVariableError(configExists bool) {
-	if configExists {
-		return
-	}
-	if err := os.RemoveAll(".ign"); err != nil {
-		printWarning(fmt.Sprintf("Failed to clean up .ign after variable parsing error: %v", err))
-	}
 }
 
 func parseVariableValue(name string, rawValue string, varDef model.VarDef) (interface{}, error) {

--- a/internal/cli/variables_test.go
+++ b/internal/cli/variables_test.go
@@ -1,0 +1,126 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/tacogips/ign/internal/template/model"
+)
+
+func TestParseVariableAssignments(t *testing.T) {
+	min := 1000.0
+	max := 9000.0
+	varDefs := map[string]model.VarDef{
+		"name": {
+			Type:     model.VarTypeString,
+			Required: true,
+			Pattern:  `^[a-z][a-z0-9-]*$`,
+		},
+		"port": {
+			Type: model.VarTypeInt,
+			Min:  &min,
+			Max:  &max,
+		},
+		"ratio": {
+			Type: model.VarTypeNumber,
+		},
+		"enabled": {
+			Type: model.VarTypeBool,
+		},
+	}
+
+	got, err := ParseVariableAssignments([]string{
+		"name=my-app",
+		"port=8080",
+		"ratio=0.75",
+		"enabled=true",
+		"name=my-other-app",
+	}, varDefs)
+	if err != nil {
+		t.Fatalf("ParseVariableAssignments() returned error: %v", err)
+	}
+
+	if got["name"] != "my-other-app" {
+		t.Fatalf("name = %v, want last repeated value", got["name"])
+	}
+	if got["port"] != 8080 {
+		t.Fatalf("port = %v, want 8080", got["port"])
+	}
+	if got["ratio"] != 0.75 {
+		t.Fatalf("ratio = %v, want 0.75", got["ratio"])
+	}
+	if got["enabled"] != true {
+		t.Fatalf("enabled = %v, want true", got["enabled"])
+	}
+}
+
+func TestParseVariableAssignments_Invalid(t *testing.T) {
+	varDefs := map[string]model.VarDef{
+		"name":    {Type: model.VarTypeString, Required: true},
+		"port":    {Type: model.VarTypeInt},
+		"enabled": {Type: model.VarTypeBool},
+	}
+
+	tests := []struct {
+		name        string
+		assignments []string
+	}{
+		{name: "missing equals", assignments: []string{"name"}},
+		{name: "empty name", assignments: []string{"=value"}},
+		{name: "unknown variable", assignments: []string{"missing=value"}},
+		{name: "empty required string", assignments: []string{"name="}},
+		{name: "invalid int", assignments: []string{"port=abc"}},
+		{name: "invalid bool", assignments: []string{"enabled=maybe"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := ParseVariableAssignments(tt.assignments, varDefs); err == nil {
+				t.Fatalf("ParseVariableAssignments() expected error")
+			}
+		})
+	}
+}
+
+func TestValidateVariableAssignmentSyntax(t *testing.T) {
+	tests := []struct {
+		name        string
+		assignments []string
+		wantErr     bool
+	}{
+		{name: "empty", assignments: nil},
+		{name: "single valid", assignments: []string{"name=value"}},
+		{name: "value contains equals", assignments: []string{"name=value=with=equals"}},
+		{name: "missing equals", assignments: []string{"name"}, wantErr: true},
+		{name: "empty name", assignments: []string{"=value"}, wantErr: true},
+		{name: "blank name", assignments: []string{"   =value"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateVariableAssignmentSyntax(tt.assignments)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateVariableAssignmentSyntax() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestPromptForVariablesWithProvided_AllProvided(t *testing.T) {
+	ignJSON := &model.IgnJson{
+		Variables: map[string]model.VarDef{
+			"name": {Type: model.VarTypeString, Required: true},
+			"port": {Type: model.VarTypeInt, Required: true},
+		},
+	}
+
+	got, err := PromptForVariablesWithProvided(ignJSON, map[string]interface{}{
+		"name": "my-app",
+		"port": 8080,
+	})
+	if err != nil {
+		t.Fatalf("PromptForVariablesWithProvided() returned error: %v", err)
+	}
+	if got["name"] != "my-app" || got["port"] != 8080 {
+		t.Fatalf("PromptForVariablesWithProvided() = %v", got)
+	}
+}

--- a/test/integration/config_init_test.go
+++ b/test/integration/config_init_test.go
@@ -239,6 +239,43 @@ func TestInit_ConditionalTemplate(t *testing.T) {
 	}
 }
 
+func TestPrepareCheckout_SkipConfigSetup(t *testing.T) {
+	tempDir := t.TempDir()
+	configDir := filepath.Join(tempDir, ".ign")
+
+	templatePath := copyFixtureToTemp(t, "simple-template", tempDir)
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current directory: %v", err)
+	}
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("failed to change to temp directory: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	prep, err := app.PrepareCheckout(context.Background(), app.PrepareCheckoutOptions{
+		URL:             templatePath,
+		SkipConfigSetup: true,
+	})
+	if err != nil {
+		t.Fatalf("PrepareCheckout with SkipConfigSetup failed: %v", err)
+	}
+	if prep == nil || prep.IgnJson == nil {
+		t.Fatalf("PrepareCheckout returned incomplete result: %#v", prep)
+	}
+	if _, err := os.Stat(configDir); !os.IsNotExist(err) {
+		t.Fatalf("config directory exists after SkipConfigSetup, stat error: %v", err)
+	}
+
+	if err := app.PrepareCheckoutConfigDir(false); err != nil {
+		t.Fatalf("PrepareCheckoutConfigDir failed: %v", err)
+	}
+	if _, err := os.Stat(configDir); err != nil {
+		t.Fatalf("config directory was not created: %v", err)
+	}
+}
+
 // TestInit_Force tests the --force flag for backup and reinitialize
 func TestInit_Force(t *testing.T) {
 	tempDir := t.TempDir()


### PR DESCRIPTION
## Summary
- Add registered `ign init` CLI command with repeatable `--var` / `-V` template variable assignments
- Add `--var` / `-V` support to one-shot `ign checkout`, with typed parsing and interactive fallback for missing variables
- Defer `.ign` creation and force-mode backups until variable parsing and prompting succeed
- Keep `ign checkout --dry-run` side-effect free for `.ign` setup
- Document the command design, progress, README usage, and project Riela workflow bundle

## Riela
- Added project workflow: `.riela/workflows/ign-variable-options`
- Verified with `riela workflow validate ign-variable-options --workflow-definition-dir .riela/workflows --output json`
- Verified with `riela workflow inspect ign-variable-options --workflow-definition-dir .riela/workflows --output json`

## Tests
- `go test ./...`
- `go vet ./...`
- `git diff --check`
- Direct CLI smoke checks for `ign init --var`, `ign checkout --var`, malformed syntax, unknown variable no-side-effect behavior, `--force` preservation, and dry-run side effects

## Unresolved TODOs
- [ ] None