### PR TITLE
Fix verified review defects and add ign vars / ign update --ref

### DIFF
--- a/.agents/skills/divedra-impl-workflow/SKILL.md
+++ b/.agents/skills/divedra-impl-workflow/SKILL.md
@@ -95,6 +95,18 @@ Because the workflow ends with commit/push, do not use it when the user has
 explicitly asked to avoid workflow-driven commits or wants manual local edits
 only.
 
+## Documentation Refresh Gate
+
+In full `issue-resolution` mode, after implementation review accepts the code,
+refresh user-facing documentation before commit-message generation. Always
+review `README.md` and this workflow skill, and update any other README or
+workflow skill whose documented behavior changed.
+
+For defect-remediation work, the docs refresh should reflect shipped behavior
+such as CLI exit/error semantics, supported flags, safety guarantees, and
+verification commands. Keep this gate documentation-only: do not reopen design
+or implementation scope after Step 7 acceptance.
+
 ## Reporting
 
 After the workflow finishes, report:

--- a/.agents/skills/divedra-impl-workflow/SKILL.md
+++ b/.agents/skills/divedra-impl-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: divedra-impl-workflow
-description: Use when implementation work in this repository changes behavior, adds functionality, or fixes bugs and the user has not explicitly asked to avoid workflows. Routes the work through the project-local divedra workflow `.divedra/workflows/design-and-implement-review-loop`, including design/plan alignment, implementation, review, user-facing documentation refresh, commit-message generation, and built-in git commit/push steps.
+description: Use when implementation work in this repository changes behavior, adds functionality, or fixes bugs and the user has not explicitly asked to avoid workflows. Routes the work through the project-local divedra workflow `divedra-workflows/design-and-implement-review-loop`, including design/plan alignment, implementation, review, user-facing documentation refresh, and final handoff.
 ---
 
 # Divedra Implementation Workflow
@@ -25,18 +25,12 @@ Use this skill as the default path for implementation work in this repository.
 Use the project-local workflow bundle:
 
 - Workflow id: `design-and-implement-review-loop`
-- Catalog path: `.divedra/workflows/design-and-implement-review-loop`
+- Workflow definition path: `divedra-workflows/design-and-implement-review-loop`
 
-Preferred entry point from the repository root:
-
-```bash
-task divedra-design-implement -- --output json
-```
-
-Equivalent direct command:
+Run from the repository root:
 
 ```bash
-nix run .#divedra -- workflow run design-and-implement-review-loop --output json
+divedra workflow run design-and-implement-review-loop --workflow-definition-dir ./divedra-workflows
 ```
 
 ## Runtime Inputs
@@ -76,9 +70,7 @@ The workflow is responsible for:
 9. implementation self-review
 10. implementation review
 11. user-facing documentation refresh (`README.md` and exposed workflow skill docs)
-12. staged secret scan with `gitleaks git --pre-commit --redact --staged --verbose`
-13. commit-message generation
-14. built-in git commit and git push add-on steps
+12. final workflow output for the accepted planning handoff or issue-resolution handoff
 
 For release or installation work, keep the supported Homebrew surface in scope:
 
@@ -91,16 +83,15 @@ For release or installation work, keep the supported Homebrew surface in scope:
   formula with `brew audit --formula --strict tacogips/tap/ign` and
   `brew test tacogips/tap/ign` when Homebrew behavior changes.
 
-Because the workflow ends with commit/push, do not use it when the user has
-explicitly asked to avoid workflow-driven commits or wants manual local edits
-only.
+The workflow does not commit or push changes automatically. If the user asks to
+commit afterward, follow the repository git commit policy.
 
 ## Documentation Refresh Gate
 
 In full `issue-resolution` mode, after implementation review accepts the code,
-refresh user-facing documentation before commit-message generation. Always
-review `README.md` and this workflow skill, and update any other README or
-workflow skill whose documented behavior changed.
+refresh user-facing documentation before final workflow output. Always review
+`README.md` and this workflow skill, and update any other README or workflow
+skill whose documented behavior changed.
 
 For defect-remediation work, the docs refresh should reflect shipped behavior
 such as CLI exit/error semantics, supported flags, safety guarantees, and
@@ -114,9 +105,8 @@ After the workflow finishes, report:
 - workflow mode
 - changed files
 - verification commands
-- commit message
-- commit hash
-- pushed remote and branch
+- documentation refresh summary
+- residual risks
 - for release work, GitHub Release URL and Homebrew tap/formula status
 
 If the workflow fails because `divedra` appears incorrect, switch to the

--- a/README.md
+++ b/README.md
@@ -120,6 +120,27 @@ Variables supplied with `--var` are used for generation and saved to
 
 After a successful checkout, ign stores the created file list in `.ign/ign-files.json`.
 
+### `ign vars`
+
+Inspect template variables and the current values stored in `.ign/ign-var.json`.
+
+```bash
+ign vars
+ign vars --json
+ign vars --unset
+ign vars --json --unset
+```
+
+The table output includes `NAME`, `TYPE`, `REQUIRED`, `DEFAULT`, `CURRENT`, and
+`DESCRIPTION`. JSON mode prints the same rows with unset counts for scripts.
+
+`--unset` shows only variables without a current value. If any known required
+variable is unset, the command exits with code `1`; otherwise it exits with code
+`0`.
+
+If template declarations cannot be fetched, `ign vars` falls back to local
+`.ign/ign-var.json` values and prints a warning outside JSON stdout.
+
 ### `ign update [output-path]`
 
 Fetch the checked-out template again and regenerate project files when the template hash has changed.
@@ -131,6 +152,9 @@ ign update --dry-run
 ign update --overwrite
 ign update --overwrite --yes
 ign update --overwrite-all
+ign update --ref v2.0.0
+ign update --ref v2.0.0 --dry-run
+ign update --ref v2.0.0 --overwrite --yes
 ```
 
 **Flags:**
@@ -143,6 +167,14 @@ ign update --overwrite-all
 | `--yes` | `-y` | Skip the overwrite confirmation prompt |
 | `--dry-run` | `-d` | Preview what would be generated without writing |
 | `--verbose` | `-v` | Show detailed processing information |
+| `--ref` | `-r` | Retarget the tracked template branch, tag, or commit SHA |
+
+`ign update --ref <ref>` fetches the stored template URL and path at the
+requested ref, then uses the normal update flow and overwrite protections. On
+successful non-dry-run completion, `.ign/ign.json` is updated to pin the
+requested ref. If the new ref has identical template content, ign still persists
+the requested ref and leaves generated files unchanged unless overwrite or force
+options request regeneration. Dry runs never change the stored ref.
 
 When `--overwrite` or `--overwrite-all` is used, `ign update` also removes project files recorded in `.ign/ign-files.json` when the current template no longer generates them. The manifest is pruned after removal, and stale manifest entries for files that are already missing are pruned without reporting a deletion. Selective overwrite does not remove paths matched by `.ign-overwrite-ignore`.
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ ign init /absolute/path/to/template
 | Condition | Action |
 |-----------|--------|
 | `.ign/` does not exist | Create `.ign/ign-var.json` |
-| `.ign/` exists | Do nothing (skip) |
+| `.ign/` exists | Return an error |
 | `.ign/` exists + `--force` | Backup existing config, then reinitialize |
 
 **Backup naming:** When `--force` is used, existing `ign-var.json` is backed up as `ign-var.json.bk1`, `ign-var.json.bk2`, etc.
@@ -97,7 +97,7 @@ ign checkout github.com/owner/repo --verbose    # Show detailed processing info
 ign checkout github.com/owner/repo --var app_name=my-app --var port=8080
 ```
 
-If `.ign/` already exists, checkout does nothing unless `--force` is used.
+If `.ign/` already exists, checkout returns an error unless `--force` is used.
 Variables supplied with `--var` are used for generation and saved to
 `.ign/ign-var.json`. Missing variables are still prompted interactively.
 
@@ -175,7 +175,9 @@ ign rewind ./my-project
 ```
 
 If `.ign/ign-files.json` exists, ign uses it directly. Otherwise it falls back to the
-currently checked-out template and variables to infer the managed files.
+currently checked-out template and variables to infer the managed files. During
+that fallback, ign removes only files whose current content matches what the
+template would generate and skips files with different user-owned content.
 
 ### `ign switch <url-or-path> [output-path]`
 
@@ -184,9 +186,23 @@ Replace the current checked-out template with a new one.
 ```bash
 ign switch github.com/owner/new-template
 ign switch ./new-local-template ./my-project
+ign switch github.com/owner/new-template --var app_name=my-app --var port=8080
 ```
 
 `ign switch` is equivalent to `ign rewind` followed by `ign checkout`.
+It supports the same repeatable `--var`/`-V` variable assignment syntax as
+`ign checkout`. Template preparation, variable validation, and prompting happen
+before the current `.ign/` directory is replaced, so failed input does not leave
+a partial replacement configuration.
+
+**Flags:**
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--ref` | `-r` | Git branch, tag, or commit SHA (default: main) |
+| `--force` | `-f` | Overwrite existing files when applying the new template |
+| `--verbose` | `-v` | Show detailed processing information |
+| `--var` | `-V` | Set a template variable as `key=value` (repeatable) |
 
 ### `ign template check [PATH]`
 
@@ -301,9 +317,16 @@ String default values support `{current_dir}` as a placeholder for the output di
 | Directive | Usage |
 |-----------|-------|
 | `@ign-if:VAR@...@ign-endif@` | Conditional block (bool) |
-| `@ign-include:PATH@` | Include another file |
+| `@ign-include:PATH@` | Include another file, resolved relative to the including file and contained within the template root |
 | `@ign-raw:CONTENT@` | Output literally (escape) |
 | `@ign-comment:TEXT@` | Template-only comment (removed) |
+
+## GitHub Template URLs
+
+ign accepts GitHub URLs in shorthand, HTTPS, SSH, and `.git` forms. URLs such
+as `https://github.com/owner/repo/tree/branch-name` select `branch-name` as the
+template ref when no subdirectory is present. Branch names that contain `/` are
+ambiguous in `/tree/` URLs; use `--ref` for those refs.
 
 ## Private Repos
 

--- a/design-docs/specs/architecture.md
+++ b/design-docs/specs/architecture.md
@@ -1,0 +1,152 @@
+# Architecture
+
+## Verified Defect Remediation
+
+This section records the design contract for fixing the verified defects from
+the full-codebase review of `ign` confirmed at commit `b4a6b19`.
+
+### Scope
+
+The workflow mode is `issue-resolution`. The change set targets:
+
+- `internal/app`: update transaction ordering, rewind fallback ownership
+  checks, update hash validation, and template metadata persistence.
+- `internal/config`: crash-safe writes for `.ign` JSON files.
+- `internal/cli`: error output, checkout exit status, switch setup timing, and
+  prompt validation.
+- `internal/template`: include resolution, raw directive parsing, GitHub URL
+  parsing, archive extraction, and path containment.
+
+All HIGH findings are mandatory. MID findings should be included when they fit
+the same defect-fix change set without adding unrelated product behavior.
+
+### Update Transaction Safety
+
+`internal/app/update.go` must treat generation and removed-managed-file cleanup
+as the mutation phase, and `.ign` persistence as the commit phase.
+
+Design rules:
+
+- `PrepareUpdate` must reject missing or malformed template hashes with the same
+  SHA-256 validation contract used by checkout.
+- `CompleteUpdate` must not write `.ign/ign.json` or `.ign/ign-var.json` before
+  generation succeeds.
+- Non-dry-run update must prepare rollback state before generation, using the
+  existing checkout rollback machinery or an equivalent app-layer helper.
+- If generation fails, generated files and overwritten files must be rolled back
+  and the previous `.ign` state must remain unchanged.
+- If stale managed-file cleanup partially fails, successfully generated files
+  and successful deletions must still be reflected in `.ign/ign-files.json`.
+  The returned error should describe cleanup failure without causing the next
+  `ign update` to falsely report that the template is already up to date.
+- If final `.ign` artifact persistence fails, file mutations from the update
+  must roll back where rollback data is available.
+
+### Crash-Safe Config Writes
+
+All writes for `.ign/ign-var.json`, `.ign/ign-files.json`, `.ign/ign.json`, and
+template-side `ign-template.json` must use one shared atomic write helper.
+
+Design rules:
+
+- The helper writes JSON bytes to a temporary file in the target directory.
+- The helper fsyncs the temporary file before rename.
+- The helper uses `os.Rename` to replace the target path atomically on the same
+  filesystem.
+- The helper cleans up temporary files on failure.
+- Callers keep their existing validation, parent-directory creation, JSON
+  marshaling, and error wrapping behavior.
+- No environment variable values or machine-local paths may be persisted into
+  config files, docs, or commit messages.
+
+### Rewind Ownership Safety
+
+`internal/app/rewind.go` may use current-template dry-run output only as a
+fallback when `.ign/ign-files.json` is missing. That fallback does not prove that
+all generated paths were actually written by `ign`.
+
+Design rules:
+
+- Manifest-backed rewind remains authoritative and unchanged.
+- In the fallback path, `ign rewind` may delete a file only when the current
+  on-disk content exactly matches the dry-run content generated for that path.
+- If a candidate file exists but content differs from dry-run content, rewind
+  must skip it and report it as not removed.
+- Directory removal remains limited to empty parent directories after accepted
+  file removals.
+- Paths still pass the existing managed-path containment checks before any
+  deletion.
+
+### Template Processing And Provider Safety
+
+Template processing must preserve documented template behavior while hardening
+path handling.
+
+Design rules:
+
+- `internal/template/generator/processor.go` must set parser `CurrentFile` to
+  the full template-root-relative filesystem path so relative
+  `@ign-include:file@` directives resolve against the including file.
+- `internal/template/parser/include.go` must use `filepath.Rel` style
+  containment, equivalent to the provider local path helper, rather than a weak
+  string prefix check.
+- `internal/template/parser/directive.go` must parse multiple raw directives on
+  one line independently. A raw directive closes at the nearest valid `@@`
+  terminator for that raw directive.
+- `internal/template/provider/url.go` must parse branch-only
+  `https://github.com/owner/repo/tree/<branch>` URLs as `Ref=<branch>` with an
+  empty template path, and must trim a trailing `.git` suffix for all GitHub URL
+  forms.
+- Slashed branch names in `/tree/` URLs remain ambiguous by URL shape and should
+  require explicit `--ref`; this is documented behavior, not a parser guess.
+- `internal/template/provider/github.go` must reject archive entries whose
+  cleaned target escapes the extraction root.
+- GitHub archive symlink entries must be rejected when their link target is
+  absolute or resolves outside the extraction root.
+
+### CLI Error And Prompt Behavior
+
+CLI error behavior is specified in `design-docs/specs/command.md`.
+
+Prompt validation design rules:
+
+- Invalid variable regex patterns must be compiled before interactive prompting
+  begins.
+- A template variable with an invalid regex pattern fails immediately with an
+  error identifying the variable, rather than entering a re-prompt loop.
+- Non-interactive `--var` validation keeps the existing fail-fast behavior.
+
+### Regression Coverage
+
+Each implemented finding must receive regression coverage in the package closest
+to the behavior:
+
+- `internal/app` tests for transactional update order, manifest persistence
+  after cleanup failure, rewind fallback content matching, and update hash
+  validation.
+- `internal/config` tests for atomic-write success and failure behavior where it
+  can be exercised without process-kill tests.
+- `internal/cli` tests for quiet error output, checkout existing-config error,
+  switch delayed `.ign` setup, switch `--var`, single error reporting, and
+  invalid prompt regex fail-fast behavior.
+- `internal/template` tests for relative include resolution, same-line raw
+  directives, GitHub URL parsing, archive path containment, symlink rejection,
+  and include path containment.
+
+Required verification commands:
+
+```bash
+gofmt
+go vet ./...
+go build ./...
+go test ./...
+```
+
+### Constraints
+
+- Follow existing Go conventions and keep the layered structure:
+  `cli -> app -> config/template`.
+- Do not add third-party dependencies.
+- Do not change public CLI behavior except where the verified findings require
+  it: checkout error exit and `ign switch --var/-V`.
+- Preserve existing behavior except where a finding identifies a defect.

--- a/design-docs/specs/command.md
+++ b/design-docs/specs/command.md
@@ -43,3 +43,41 @@ ign checkout ./template ./out -V project_name=my-app -V enable_feature=true
 Before this design, the CLI had no registered `ign init` command and one-shot
 `ign checkout` always called the interactive prompt helper for all template
 variables. There was no CLI option for non-interactive variable assignment.
+
+## Defect-Fix CLI Semantics
+
+This section records CLI behavior required by the verified defect remediation
+work in `design-docs/specs/architecture.md`.
+
+### Error Output
+
+- `--quiet` suppresses non-error output only.
+- Cobra-level and command-returned errors must always print to stderr.
+- Each failure should be reported once. Command `RunE` handlers should return
+  errors and avoid printing the same error that `Execute` will print.
+- `RunE` handlers must not call `os.Exit`; they should return errors so deferred
+  cleanup and the root error path remain consistent.
+
+### Checkout Existing Configuration
+
+- `ign checkout <url-or-path> [output-path]` must return a non-zero exit when
+  `.ign` already exists and `--force` is absent.
+- The behavior should match `ign init`: report that configuration already exists
+  and return an error instead of succeeding after informational output.
+
+### Switch Variables And Setup Timing
+
+- `ign switch <url-or-path> [output-path]` supports repeatable
+  `--var key=value` and short `-V key=value` with the same parsing and
+  validation semantics as `ign checkout`.
+- `ign switch` must prepare and validate the new template without creating or
+  backing up `.ign` before variable parsing and prompting complete.
+- If variable parsing, validation, or prompting fails, switch leaves the current
+  `.ign` state untouched.
+
+### GitHub Tree URL Ambiguity
+
+- `https://github.com/owner/repo/tree/<branch>` with no subdirectory resolves to
+  `owner/repo` at ref `<branch>`.
+- Branch names containing slashes are ambiguous in `/tree/` URLs. Users must use
+  `--ref` for those refs instead of relying on path parsing.

--- a/design-docs/specs/ign-update-ref.md
+++ b/design-docs/specs/ign-update-ref.md
@@ -1,0 +1,191 @@
+# Add `ign update --ref <ref>` Flag
+
+Feature-local design for `ign-update-ref`, adding non-destructive template ref
+retargeting to the existing `ign update` flow.
+
+## Feature Contract
+
+- Workflow mode: `issue-resolution`
+- Issue reference: `workflowInput.issueBody FEATURE 2: 'ign update --ref <ref>' - retarget the tracked branch/tag`
+- Feature id: `ign-update-ref`
+- Feature title: Add `ign update --ref <ref>` flag
+- Declared design document: `design-docs/specs/ign-update-ref.md`
+- Implementation plan target: `impl-plans/ign-update-ref.md`
+- Target areas: `internal/cli`, `internal/app`
+- Codex agent references:
+  - `.agents/agents/go-coding.md`
+  - `.agents/agents/go-check-and-test-after-modify.md`
+
+## Summary
+
+`ign update --ref <ref>` lets a checked-out project retarget the template branch,
+tag, or commit recorded in `.ign/ign.json` without using the destructive
+`ign switch` flow. The command keeps the configured template URL and path,
+fetches the template at the requested ref, compares hashes, and then uses the
+normal update protections for generation, overwrite handling, dry runs, and
+rollback-safe artifact persistence.
+
+Without `--ref`, `ign update` must continue using the stored
+`.ign/ign.json.template.ref` with no behavior changes.
+
+## CLI Behavior
+
+Add a string `--ref` flag to `internal/cli/update.go`; use short `-r` for
+consistency with `ign checkout --ref` and `ign switch --ref`.
+
+Supported examples:
+
+```bash
+ign update --ref v2.0.0
+ign update --ref release/2026.07 --dry-run
+ign update --ref v2.0.0 --overwrite --yes
+ign update ./my-project --ref v2.0.0 --force
+```
+
+Design rules:
+
+- `--ref` composes with `--dry-run`, `--overwrite`, `--overwrite-all`, `--yes`,
+  and `--force`.
+- The CLI validates a supplied ref before calling `app.PrepareUpdate`, so
+  invalid refs fail before provider or network access.
+- The CLI threads the requested ref through `app.UpdateOptions`.
+- Output shows the effective ref when `--ref` is supplied, including `main`
+  when the user explicitly requested it.
+- If the requested ref resolves to identical template content, output notes that
+  content is identical while still allowing the pin update on successful
+  non-dry-run completion.
+- `--dry-run --ref <ref>` fetches and previews against the requested ref but
+  leaves `.ign/ign.json`, `.ign/ign-var.json`, and `.ign/ign-files.json`
+  unchanged.
+
+## App-Layer Behavior
+
+Extend `app.UpdateOptions` with an optional ref override field, for example
+`TargetRef string`.
+
+`PrepareUpdate` remains responsible for loading current `.ign` state, resolving
+the provider, fetching the template, validating the template hash, comparing
+hashes, and identifying variable changes.
+
+Design rules:
+
+- Load `.ign/ign.json` and `.ign/ign-var.json` before fetching, matching current
+  update behavior and missing-configuration errors.
+- Preserve the configured template URL and path; `--ref` changes only
+  `.ign/ign.json.template.ref`.
+- Validate `TargetRef` in `internal/app` as a defense for non-CLI callers
+  without importing `internal/cli`.
+- Apply the ref override to the in-memory `model.TemplateRef` before provider
+  fetch and hash comparison.
+- Keep previous config state available for rollback before mutating the loaded
+  config object.
+- Add preparation result fields for requested ref, previous ref, effective ref,
+  whether a ref override was requested, whether the stored ref changes, and
+  whether content hash changes.
+- Continue using the fetched template's `ign-template.json` hash as
+  `PrepareUpdateResult.NewHash`.
+
+## Persistence And Transaction Safety
+
+`CompleteUpdate` remains the non-dry-run path that commits update artifacts. The
+feature must preserve the transaction ordering used by update: generation and
+removed-file cleanup happen before `.ign` artifact writes, and artifact writes
+use snapshots so failures can restore previous state.
+
+Design rules:
+
+- On successful non-dry-run completion, persist both `.ign/ign.json.hash =
+  NewHash` and `.ign/ign.json.template.ref = requested ref`.
+- If generation or cleanup fails before artifact persistence, keep the previous
+  ref in `.ign/ign.json`.
+- If saving `.ign/ign.json`, `.ign/ign-var.json`, or `.ign/ign-files.json`
+  fails, rollback restores the previous ref with the previous hash, variables,
+  and manifest.
+- When the requested ref is different but the content hash is identical, skip
+  project-file regeneration and persist the requested ref through a
+  configuration-only commit path that still uses rollback-safe artifact
+  snapshots.
+- Do not require `--overwrite` or `--force` to persist an identical-content ref
+  retarget.
+- Dry runs never persist the requested ref.
+
+## Regeneration Decision
+
+Existing update regeneration remains based on hash changes, `--force`, or
+overwrite mode. `--ref` adds one separate completion reason:
+`refChanged && !dryRun`.
+
+When only the ref changed and the hash is identical, completion should update
+configuration without rewriting project files or replacing the managed-file
+manifest with an empty generation result.
+
+## Test Design
+
+Unit tests:
+
+- `internal/cli/update_test.go`: registers `--ref` and `-r`.
+- `internal/cli/update_test.go`: parses `--ref` and forwards it through update
+  options.
+- `internal/cli/update_test.go`: invalid refs fail before app update execution.
+- `internal/app/update_test.go`: `PrepareUpdate` fetches the requested ref and
+  preserves stored URL and path.
+- `internal/app/update_test.go`: invalid `TargetRef` is rejected in the app
+  layer.
+- `internal/app/update_test.go`: identical-hash ref retarget persists
+  `.ign/ign.json.template.ref` without rewriting project files.
+- `internal/app/update_test.go`: dry-run ref retarget leaves `.ign/ign.json`
+  unchanged.
+- `internal/app/update_test.go`: save failure rolls back the previous ref.
+- `internal/app/update_test.go`: absent `TargetRef` preserves existing behavior.
+
+Integration tests:
+
+- `test/integration`: update a checked-out fixture with `--ref` to a newer
+  template version and verify generated files plus `.ign/ign.json.template.ref`.
+- `test/integration`: update with `--ref` where content hash is unchanged and
+  verify the ref is persisted while generated files are not rewritten.
+- `test/integration`: update with `--ref --dry-run` and verify preview output
+  plus unchanged config.
+- `test/integration`: update with `--ref --overwrite --yes` and verify existing
+  overwrite protections, including `.ign-overwrite-ignore`, still apply.
+
+Required verification commands:
+
+```bash
+gofmt -w <modified-go-files>
+go vet ./...
+go build ./...
+go test ./...
+```
+
+## Decisions
+
+- Reuse `ign update` instead of adding a new command because retargeting is an
+  update concern and must compose with update protections.
+- Keep retargeting non-destructive; it must not call the `ign switch` or
+  `ign rewind` flows.
+- Persist the requested ref even when content is identical so `.ign/ign.json`
+  records the user's requested pin.
+- Validate refs in both CLI and app layers, centralizing the rule in a neutral
+  package if that avoids drift.
+- Keep dry-run strictly preview-only.
+
+## Addressed Feedback
+
+- No upstream review feedback or mailbox payloads were attached to this branch
+  execution.
+- The design uses the declared fanout feature contract for `ign-update-ref`
+  rather than the similarly named historical design documents already present.
+
+## Open Questions
+
+- None.
+
+## Risks
+
+- Identical-content ref retargeting needs a configuration-only commit path; if
+  it bypasses artifact snapshots, rollback guarantees can regress.
+- Ref validation can drift if duplicated between CLI and app layers.
+- Local provider fixtures cannot fully emulate remote git ref resolution, so
+  integration tests should separate persisted-config assertions from remote
+  ref-switching behavior.

--- a/design-docs/specs/ign-vars.md
+++ b/design-docs/specs/ign-vars.md
@@ -1,0 +1,221 @@
+# Add `ign vars` Command
+
+Feature-local design for issue-resolution work on FEATURE 1 from
+`Add ign vars command and ign update --ref flag`.
+
+## Feature Contract
+
+- Workflow mode: `issue-resolution`
+- Issue reference: `workflowInput.issueBody FEATURE 1: 'ign vars' - inspect
+  template variables and current values`
+- Feature id: `ign-vars`
+- Feature title: Add `ign vars` command
+- Design document path: `design-docs/specs/ign-vars.md`
+- Implementation plan path: `impl-plans/ign-vars.md`
+- Implementation target: `internal/cli`, `internal/app`, `internal/config`,
+  `internal/template`
+- Codex agent references: `.agents/agents/go-coding.md`,
+  `.agents/agents/go-check-and-test-after-modify.md`
+
+## Overview
+
+`ign vars` gives project users a direct way to inspect the variables declared by
+the tracked template and the current values stored in `.ign/ign-var.json`.
+The command is read-only and follows the existing layered structure:
+`internal/cli` handles flags and output formatting, `internal/app` loads project
+state and prepares display data, and `internal/config` plus
+`internal/template` continue to own JSON loading and template fetching.
+
+## Command Surface
+
+```bash
+ign vars
+ign vars --json
+ign vars --unset
+ign vars --json --unset
+```
+
+Flags:
+
+- `--json`: print machine-readable variable rows as JSON.
+- `--unset`: include only variables with no current value.
+
+Output columns for table mode:
+
+- `NAME`
+- `TYPE`
+- `REQUIRED`
+- `DEFAULT`
+- `CURRENT`
+- `DESCRIPTION`
+
+Global behavior:
+
+- `--quiet` suppresses normal table, JSON, and warning output but must not
+  suppress errors.
+- `--no-color` is respected by using existing CLI output helpers and avoiding
+  new color-specific formatting.
+- When `.ign` configuration is missing or invalid, return an error consistent
+  with `ign update` and `ign rewind` setup failures.
+
+## App-Layer Contract
+
+Add `internal/app/vars.go` with an app-facing query API that returns a stable
+result independent of CLI formatting.
+
+The app result should include:
+
+- declaration availability, so the CLI can distinguish full template metadata
+  from local-only fallback output;
+- sorted variable rows for deterministic table, JSON, and test output;
+- unset counts split by all known unset variables and required unset variables;
+- a non-fatal fetch error when declarations are unavailable.
+
+Each variable row should include:
+
+- name;
+- declared type, required flag, default, and description when a declaration is
+  available;
+- current value from `.ign/ign-var.json`;
+- unset state computed from current value presence, not from default presence.
+
+Unset semantics:
+
+- A variable is unset when its key is absent from `.ign/ign-var.json`.
+- Explicit `null`, `false`, `0`, or empty string values are still current values
+  if they are stored.
+- `--unset` filters to unset rows after declarations and current values are
+  merged.
+- `ign vars --unset` exits with code `1` only when at least one required known
+  variable is unset; otherwise it exits `0`.
+
+## Data Flow
+
+1. Load `.ign/ign.json` from `.ign/ign.json`.
+2. Load `.ign/ign-var.json` from `.ign/ign-var.json`.
+3. Resolve and fetch the configured template source using the same provider path
+   as update/checkout, including stored `template.url`, `template.ref`, and
+   `template.path`.
+4. Merge fetched `IgnJson.Variables` declarations with current values.
+5. Include local-only rows for values present in `.ign/ign-var.json` but absent
+   from template declarations.
+6. If template fetch fails, return rows for local values only and include a
+   declaration-unavailable warning in the result.
+
+The local-only fallback is intentionally best-effort:
+
+- it exits `0` for normal listing because no known declarations can prove a
+  required value is missing;
+- `--unset` can only report missing required variables when declarations are
+  available;
+- the CLI should print a concise warning unless `--quiet` is set.
+- JSON output keeps warning text off stdout so scripts receive valid JSON.
+
+## CLI Responsibilities
+
+Add `internal/cli/vars.go` and register it from `internal/cli/root.go`.
+
+The CLI layer should:
+
+- parse `--json` and `--unset`;
+- call the app-layer vars query;
+- format table output with deterministic row order;
+- format JSON output with the same fields represented by table mode plus unset
+  state, current-value presence, and result counts;
+- map app errors directly to Cobra `RunE` returns;
+- return a sentinel or typed app result error for the required-unset condition
+  so `Execute` exits non-zero without duplicate error printing.
+- keep declaration-unavailable warnings on stderr or the existing warning
+  channel so `--json` stdout remains valid JSON.
+
+Recommended JSON shape:
+
+```json
+{
+  "declarations_available": true,
+  "variables": [
+    {
+      "name": "project_name",
+      "type": "string",
+      "required": true,
+      "default": null,
+      "current": "my-app",
+      "has_current": true,
+      "description": "Project name",
+      "unset": false
+    }
+  ],
+  "unset_count": 0,
+  "required_unset_count": 0
+}
+```
+
+## Boundaries And Reuse
+
+- Do not add third-party dependencies.
+- Reuse `config.LoadIgnConfig` and `config.LoadIgnVarJson`.
+- Reuse provider resolution/fetch behavior already used by
+  `app.PrepareUpdate`; avoid duplicating URL normalization semantics.
+- Reuse existing variable default and validation concepts where they apply, but
+  do not prompt, mutate `.ign`, generate files, or validate checkout readiness.
+- Keep formatting helpers in `internal/cli/output.go` as the source of truth for
+  quiet/error behavior.
+
+## Tests
+
+Unit coverage:
+
+- `internal/app/vars_test.go`: successful declaration/current merge, sorted
+  rows, missing current values, required-unset exit condition data, local-only
+  fallback when template fetch fails, and missing `.ign` errors.
+- `internal/cli/vars_test.go`: flag registration, table output, JSON output,
+  `--unset` filtering, quiet suppression, and required-unset non-zero behavior.
+
+Integration coverage:
+
+- `test/integration`: checkout or seed a local template, run `ign vars`, run
+  `ign vars --json`, and run `ign vars --unset` with both satisfied and missing
+  required variables.
+
+Documentation:
+
+- Refresh `README.md` command documentation with `ign vars`, `--json`, and
+  `--unset` examples.
+
+Verification commands:
+
+```bash
+gofmt
+go vet ./...
+go build ./...
+go test ./...
+```
+
+## Decisions
+
+- `ign vars` is read-only and must not update `.ign` files or template hashes.
+- Current values are only values explicitly stored in `.ign/ign-var.json`;
+  defaults are displayed separately and do not make a variable "set".
+- Offline or failed template fetch degrades to local value listing instead of a
+  hard failure, because the command still provides useful inspection of local
+  state.
+- Missing declarations prevent required-unset failure because requiredness is
+  unknown.
+- Deterministic sorting by variable name is required for stable CLI output and
+  tests.
+- Warnings for unavailable declarations should not be emitted on JSON stdout.
+
+## Open Questions
+
+- None for this feature-local design; the issue body defines the command
+  surface, fallback behavior, test scope, and documentation scope.
+
+## Risks
+
+- Provider fetch reuse may currently be embedded in `PrepareUpdate`; extracting
+  a small shared helper may be needed to avoid duplicating ref/path override
+  behavior.
+- CLI JSON output must remain script-friendly; avoid colored prefixes or warning
+  text on stdout when `--json` is selected.
+- The required-unset exit path needs care so Cobra prints no noisy duplicate
+  error while still returning exit code `1`.

--- a/docs/progress/ign-update-ref.md
+++ b/docs/progress/ign-update-ref.md
@@ -1,0 +1,31 @@
+# ign update --ref
+
+**Status**: Completed
+
+## Spec Reference
+
+- `design-docs/specs/ign-update-ref.md`
+- `impl-plans/ign-update-ref.md`
+
+## Implemented
+
+- [x] Added shared git ref validation (`internal/app/ref_validation.go`)
+- [x] Added `ign update --ref` / `-r` CLI flag (`internal/cli/update.go`)
+- [x] Threaded target refs through update preparation (`internal/app/update.go`)
+- [x] Persisted requested refs on successful non-dry-run completion, including identical-content retargets (`internal/app/update.go`)
+- [x] Added unit and integration tests (`internal/app/update_test.go`, `internal/cli/update_test.go`, `test/integration/update_ref_test.go`)
+- [x] Updated command documentation (`README.md`)
+
+## Remaining
+
+- [ ] None
+
+## Design Decisions
+
+- Centralize ref validation in `internal/app` and keep the CLI wrapper delegated to it.
+- Use a config-only completion path for identical-content retargets when neither overwrite nor force requests regeneration.
+- Preserve dry-run semantics by leaving `.ign/ign.json` unchanged.
+
+## Notes
+
+- Local integration fixtures verify persisted refs and dry-run behavior. Remote provider ref resolution remains covered by provider-level behavior.

--- a/docs/progress/ign-vars.md
+++ b/docs/progress/ign-vars.md
@@ -1,0 +1,30 @@
+# ign vars
+
+**Status**: Completed
+
+## Spec Reference
+
+- `design-docs/specs/ign-vars.md`
+- `impl-plans/ign-vars.md`
+
+## Implemented
+
+- [x] Added read-only app-layer variable inspection (`internal/app/vars.go`)
+- [x] Added shared tracked-template fetch helper (`internal/app/template_fetch.go`)
+- [x] Added `ign vars`, `--json`, and `--unset` CLI support (`internal/cli/vars.go`, `internal/cli/root.go`)
+- [x] Added unit and integration tests (`internal/app/vars_test.go`, `internal/cli/vars_test.go`, `test/integration/vars_test.go`)
+- [x] Updated command documentation (`README.md`)
+
+## Remaining
+
+- [ ] None
+
+## Design Decisions
+
+- Treat key absence as unset; present `false`, `0`, empty string, and `nil` values remain current values.
+- Keep declaration fetch failures non-fatal and return local-only rows.
+- Route declaration warnings to stderr so JSON stdout remains parseable.
+
+## Notes
+
+- Offline fallback cannot identify missing required variables when declarations are unavailable.

--- a/docs/progress/verified-defect-remediation.md
+++ b/docs/progress/verified-defect-remediation.md
@@ -1,0 +1,43 @@
+# Verified Defect Remediation
+
+**Status**: Completed
+
+## Spec Reference
+
+- `design-docs/specs/architecture.md` Section: Verified Defect Remediation
+- `design-docs/specs/command.md` Section: Defect-Fix CLI Semantics
+- `impl-plans/active/verified-defect-remediation.md`
+
+## Implemented
+
+- [x] HIGH-1 update transaction ordering and partial-cleanup manifest persistence (`internal/app/update.go`, `internal/app/update_test.go`)
+- [x] HIGH-2 atomic JSON persistence helper for config, manifest, variable, and template JSON writes (`internal/config/loader.go`, `internal/app/template_update.go`)
+- [x] HIGH-3 rewind missing-manifest fallback content ownership check (`internal/app/rewind.go`, `internal/app/rewind_test.go`)
+- [x] HIGH-4 quiet mode keeps error output visible (`internal/cli/root.go`, `internal/cli/cli_test.go`)
+- [x] HIGH-5 checkout existing `.ign` without `--force` returns an error (`internal/cli/checkout.go`, `internal/cli/checkout_test.go`)
+- [x] HIGH-6 relative include resolution from the including template file (`internal/template/generator/processor.go`, `internal/template/parser/include.go`)
+- [x] MID-1 same-line raw directives parse independently (`internal/template/parser/directive.go`, `internal/template/parser/parser_test.go`)
+- [x] MID-2 GitHub `/tree/<branch>` and trailing `.git` URL parsing (`internal/template/provider/url.go`, `internal/template/provider/provider_test.go`)
+- [x] MID-3 include and GitHub archive extraction containment hardening (`internal/template/parser/include.go`, `internal/template/provider/github.go`)
+- [x] MID-4 single root error-reporting path and no `os.Exit` inside `RunE` (`internal/cli/*.go`)
+- [x] MID-5 switch delays `.ign` setup and supports `--var/-V` (`internal/cli/switch.go`, `internal/cli/switch_test.go`)
+- [x] MID-6 update rejects malformed template hashes (`internal/app/update.go`, `internal/app/update_test.go`)
+- [x] MID-7 invalid interactive regex patterns fail before prompting (`internal/cli/prompt.go`, `internal/cli/prompt_test.go`)
+
+## Remaining
+
+- None.
+
+## Design Decisions
+
+- Update uses the existing checkout rollback snapshot machinery for generated writes and artifact-save failures.
+- Cleanup partial failures are treated as applied updates after successful generation; the manifest is saved before returning the cleanup error so successful writes and deletions are not lost.
+- Rewind fallback deletes only files whose current bytes match generated dry-run bytes.
+- CLI handlers return errors to the root command; template validation details remain printed before returning a single validation error.
+- GitHub archive extraction rejects target paths and symlink targets that resolve outside the extraction directory.
+
+## Notes
+
+- No new third-party dependencies were added.
+- Focused package verification passed with `go test ./internal/config ./internal/app ./internal/cli ./internal/template/generator ./internal/template/parser ./internal/template/provider`.
+- Final verification passed with `gofmt`, `go vet ./...`, `go build ./...`, and `go test ./...`.

--- a/impl-plans/PROGRESS.json
+++ b/impl-plans/PROGRESS.json
@@ -1,6 +1,63 @@
 {
-  "lastUpdated": "2026-05-31T13:38:28Z",
+  "lastUpdated": "2026-07-12T00:00:00Z",
   "plans": {
+    "verified-defect-remediation": {
+      "path": "impl-plans/active/verified-defect-remediation.md",
+      "phase": 2,
+      "status": "Completed",
+      "updated": "2026-07-12",
+      "tasks": {
+        "TASK-001": {
+          "status": "Completed",
+          "parallelizable": true,
+          "deps": []
+        },
+        "TASK-002": {
+          "status": "Completed",
+          "parallelizable": true,
+          "deps": []
+        },
+        "TASK-003": {
+          "status": "Completed",
+          "parallelizable": true,
+          "deps": []
+        },
+        "TASK-004": {
+          "status": "Completed",
+          "parallelizable": true,
+          "deps": []
+        },
+        "TASK-005": {
+          "status": "Completed",
+          "parallelizable": true,
+          "deps": []
+        },
+        "TASK-006": {
+          "status": "Completed",
+          "parallelizable": true,
+          "deps": []
+        },
+        "TASK-007": {
+          "status": "Completed",
+          "parallelizable": false,
+          "deps": [
+            "TASK-001",
+            "TASK-002",
+            "TASK-003",
+            "TASK-004",
+            "TASK-005",
+            "TASK-006"
+          ]
+        },
+        "TASK-008": {
+          "status": "Completed",
+          "parallelizable": false,
+          "deps": [
+            "TASK-007"
+          ]
+        }
+      }
+    },
     "selective-overwrite": {
       "path": "impl-plans/selective-overwrite.md",
       "phase": 2,

--- a/impl-plans/PROGRESS.json
+++ b/impl-plans/PROGRESS.json
@@ -1,6 +1,119 @@
 {
-  "lastUpdated": "2026-07-12T00:00:00Z",
+  "lastUpdated": "2026-07-13T00:00:00Z",
   "plans": {
+    "ign-vars": {
+      "path": "impl-plans/ign-vars.md",
+      "phase": 2,
+      "status": "Completed",
+      "updated": "2026-07-13",
+      "tasks": {
+        "TASK-001": {
+          "status": "Completed",
+          "parallelizable": true,
+          "deps": []
+        },
+        "TASK-002": {
+          "status": "Completed",
+          "parallelizable": true,
+          "deps": []
+        },
+        "TASK-003": {
+          "status": "Completed",
+          "parallelizable": false,
+          "deps": [
+            "TASK-001"
+          ]
+        },
+        "TASK-004": {
+          "status": "Completed",
+          "parallelizable": false,
+          "deps": [
+            "TASK-003"
+          ]
+        },
+        "TASK-005": {
+          "status": "Completed",
+          "parallelizable": false,
+          "deps": [
+            "TASK-003"
+          ]
+        },
+        "TASK-006": {
+          "status": "Completed",
+          "parallelizable": false,
+          "deps": [
+            "TASK-001",
+            "TASK-002",
+            "TASK-003",
+            "TASK-004",
+            "TASK-005"
+          ]
+        }
+      }
+    },
+    "ign-update-ref": {
+      "path": "impl-plans/ign-update-ref.md",
+      "phase": 2,
+      "status": "Completed",
+      "updated": "2026-07-13",
+      "tasks": {
+        "TASK-001": {
+          "status": "Completed",
+          "parallelizable": true,
+          "deps": []
+        },
+        "TASK-002": {
+          "status": "Completed",
+          "parallelizable": false,
+          "deps": [
+            "TASK-001"
+          ]
+        },
+        "TASK-003": {
+          "status": "Completed",
+          "parallelizable": false,
+          "deps": [
+            "TASK-001"
+          ]
+        },
+        "TASK-004": {
+          "status": "Completed",
+          "parallelizable": false,
+          "deps": [
+            "TASK-003"
+          ]
+        },
+        "TASK-005": {
+          "status": "Completed",
+          "parallelizable": false,
+          "deps": [
+            "TASK-002",
+            "TASK-004"
+          ]
+        },
+        "TASK-006": {
+          "status": "Completed",
+          "parallelizable": false,
+          "deps": [
+            "TASK-004"
+          ]
+        },
+        "TASK-007": {
+          "status": "Completed",
+          "parallelizable": true,
+          "deps": []
+        },
+        "TASK-008": {
+          "status": "Completed",
+          "parallelizable": false,
+          "deps": [
+            "TASK-005",
+            "TASK-006",
+            "TASK-007"
+          ]
+        }
+      }
+    },
     "verified-defect-remediation": {
       "path": "impl-plans/active/verified-defect-remediation.md",
       "phase": 2,

--- a/impl-plans/README.md
+++ b/impl-plans/README.md
@@ -4,7 +4,9 @@ Implementation plans for this repository live here. Track status in PROGRESS.jso
 
 ## Plans
 
-- `impl-plans/active/verified-defect-remediation.md`: ready plan for fixing
+- `impl-plans/ign-update-ref.md`: completed plan for adding non-destructive `ign update --ref <ref>` retargeting.
+- `impl-plans/ign-vars.md`: completed plan for the `ign vars` variable inspection command.
+- `impl-plans/active/verified-defect-remediation.md`: completed plan for fixing
   verified defects from the full-codebase review of `ign`.
 - `impl-plans/selective-overwrite.md`: completed selective-overwrite implementation plan.
 - `impl-plans/update-overwrite-cleanup-review.md`: completed follow-up plan for reviewing and improving stale managed file cleanup during update overwrite.

--- a/impl-plans/README.md
+++ b/impl-plans/README.md
@@ -4,5 +4,7 @@ Implementation plans for this repository live here. Track status in PROGRESS.jso
 
 ## Plans
 
+- `impl-plans/active/verified-defect-remediation.md`: ready plan for fixing
+  verified defects from the full-codebase review of `ign`.
 - `impl-plans/selective-overwrite.md`: completed selective-overwrite implementation plan.
 - `impl-plans/update-overwrite-cleanup-review.md`: completed follow-up plan for reviewing and improving stale managed file cleanup during update overwrite.

--- a/impl-plans/active/verified-defect-remediation.md
+++ b/impl-plans/active/verified-defect-remediation.md
@@ -1,0 +1,484 @@
+# Verified Defect Remediation Implementation Plan
+
+**Status**: Completed
+**Design Reference**: `design-docs/specs/architecture.md#verified-defect-remediation`, `design-docs/specs/command.md#defect-fix-cli-semantics`
+**Created**: 2026-07-12
+**Last Updated**: 2026-07-12
+
+---
+
+## Design Document Reference
+
+**Sources**:
+
+- `design-docs/specs/architecture.md#verified-defect-remediation`
+- `design-docs/specs/command.md#defect-fix-cli-semantics`
+
+### Summary
+
+Implement the accepted issue-resolution design for verified defects in
+`internal/app`, `internal/cli`, `internal/config`, and `internal/template`.
+All HIGH findings are mandatory. The listed MID findings are included because
+they fit one coherent defect-remediation change set and share verification
+scope with the HIGH fixes.
+
+### Scope
+
+**Included**:
+
+- HIGH-1 update transaction safety and manifest persistence after partial
+  cleanup failure.
+- HIGH-2 crash-safe config/template JSON writes.
+- HIGH-3 rewind fallback ownership safety.
+- HIGH-4 and HIGH-5 CLI error output and checkout exit behavior.
+- HIGH-6 relative include resolution.
+- MID-1 through MID-7 parser, provider, CLI, switch, update hash, and prompt
+  fixes.
+- Regression tests for each implemented finding.
+- Progress-log update under `docs/progress/`.
+
+**Excluded**:
+
+- Unrelated feature work.
+- New third-party dependencies.
+- Public CLI changes except checkout non-zero existing-config behavior and
+  `ign switch --var/-V`.
+
+### Codex-Agent References
+
+- `.agents/agents/go-coding.md`: required for Step 6 Go implementation with
+  Purpose, Reference Document, Implementation Target, and Completion Criteria.
+- `.agents/agents/go-check-and-test-after-modify.md`: required after Go file
+  modifications and for requested Go checks.
+
+No external codex-agent reference repository or behavior input was supplied.
+
+---
+
+## Modules
+
+### 1. Update Transaction And Hash Validation
+
+**Files**:
+
+- `internal/app/update.go`
+- `internal/app/update_cleanup.go`
+- `internal/app/manifest.go`
+- `internal/app/update_test.go`
+
+**Status**: COMPLETED
+
+```go
+func PrepareUpdate(ctx context.Context, opts UpdateOptions) (*PrepareUpdateResult, error)
+func CompleteUpdate(ctx context.Context, opts CompleteUpdateOptions) (*UpdateResult, error)
+func validateTemplateHash(hash string) error
+func cleanupRemovedManagedFilesForUpdate(ctx context.Context, opts cleanupRemovedManagedFilesOptions) (*cleanupRemovedManagedFilesResult, error)
+func saveManifestFromGenerateResultExcluding(path string, result *generator.GenerateResult, excludedCanonicalPaths map[string]struct{}) error
+```
+
+**Checklist**:
+
+- [x] Validate new update template hashes with checkout's SHA-256 contract.
+- [x] Generate and clean up removed managed files before saving `.ign/ign.json`
+      or `.ign/ign-var.json`.
+- [x] Reuse existing checkout rollback machinery or an app-layer equivalent for
+      update file rollback.
+- [x] Preserve previous `.ign` state when generation fails.
+- [x] Persist manifest entries for successful writes and successful deletions
+      even when cleanup returns a partial failure.
+- [x] Add regression tests for HIGH-1 and MID-6.
+
+### 2. Atomic JSON Persistence
+
+**Files**:
+
+- `internal/config/loader.go`
+- `internal/config/config_test.go`
+- `internal/app/template_update.go`
+- `internal/app/template_update_test.go`
+
+**Status**: COMPLETED
+
+```go
+func SaveIgnVarJson(path string, ignVar *model.IgnVarJson) error
+func SaveIgnManifest(path string, manifest *model.IgnManifest) error
+func SaveIgnConfig(path string, ignConfig *model.IgnConfig) error
+func updateIgnJson(path string, result *UpdateTemplateResult, existing *model.IgnJson, merge bool) error
+```
+
+**Checklist**:
+
+- [x] Add one shared same-directory temp-file, fsync, and rename helper.
+- [x] Use the helper for `.ign/ign-var.json`, `.ign/ign-files.json`,
+      `.ign/ign.json`, and template-side `ign-template.json`.
+- [x] Preserve existing marshaling, validation, permissions, directory creation,
+      and error wrapping behavior.
+- [x] Clean up temporary files on failure.
+- [x] Add regression tests for HIGH-2 behavior that can be exercised without
+      process-kill tests.
+
+### 3. Rewind Fallback Ownership Safety
+
+**Files**:
+
+- `internal/app/rewind.go`
+- `internal/app/rewind_test.go`
+
+**Status**: COMPLETED
+
+```go
+func Rewind(ctx context.Context, opts RewindOptions) (*RewindResult, error)
+func buildManagedFilesFromCurrentTemplate(ctx context.Context, opts RewindOptions) ([]string, error)
+```
+
+**Checklist**:
+
+- [x] Keep manifest-backed rewind behavior authoritative.
+- [x] In the missing-manifest fallback, compare current on-disk content with
+      dry-run generated content before deleting.
+- [x] Skip fallback candidates whose content differs.
+- [x] Keep existing containment and empty-directory cleanup behavior.
+- [x] Add regression tests for HIGH-3.
+
+### 4. CLI Error, Checkout, Switch, And Prompt Semantics
+
+**Files**:
+
+- `internal/cli/root.go`
+- `internal/cli/output.go`
+- `internal/cli/checkout.go`
+- `internal/cli/template.go`
+- `internal/cli/switch.go`
+- `internal/cli/prompt.go`
+- `internal/cli/cli_test.go`
+- `internal/cli/checkout_test.go`
+- `internal/cli/switch_test.go`
+- `internal/cli/prompt_test.go`
+
+**Status**: COMPLETED
+
+```go
+func Execute()
+func printError(err error)
+func runCheckout(cmd *cobra.Command, args []string) error
+func runSwitch(cmd *cobra.Command, args []string) error
+func promptForVariable(name string, varDef model.VarDef) (interface{}, error)
+func matchPattern(pattern string, message string) survey.Validator
+```
+
+**Checklist**:
+
+- [x] Ensure `--quiet` suppresses non-error output only.
+- [x] Make command failures print once through the root error path.
+- [x] Return an error when checkout finds existing `.ign` without `--force`.
+- [x] Replace `os.Exit` inside `RunE` with returned errors.
+- [x] Delay switch `.ign` setup until after variable parsing and prompting.
+- [x] Add `ign switch --var/-V` using checkout/init variable semantics.
+- [x] Compile invalid prompt regex patterns before prompting and fail fast with
+      the variable name.
+- [x] Add regression tests for HIGH-4, HIGH-5, MID-4, MID-5, and MID-7.
+
+### 5. Template Parser And Generator Safety
+
+**Files**:
+
+- `internal/template/generator/processor.go`
+- `internal/template/generator/generator_test.go`
+- `internal/template/parser/directive.go`
+- `internal/template/parser/include.go`
+- `internal/template/parser/parser_test.go`
+
+**Status**: COMPLETED
+
+```go
+func (p *FileProcessor) Process(ctx context.Context, file model.TemplateFile, vars parser.Variables, templateRoot string) ([]byte, error)
+func resolveIncludePath(includePath, templateRoot, currentFile string) (string, error)
+func findDirectives(input []byte) []DirectiveMatch
+```
+
+**Checklist**:
+
+- [x] Pass a full template-root-relative filesystem path as parser
+      `CurrentFile` during generation.
+- [x] Use `filepath.Rel` style containment for include path validation.
+- [x] Parse same-line raw directives independently with nearest valid `@@`
+      termination.
+- [x] Add regression tests for HIGH-6, MID-1, and include containment in MID-3.
+
+### 6. GitHub URL And Archive Hardening
+
+**Files**:
+
+- `internal/template/provider/url.go`
+- `internal/template/provider/provider_test.go`
+- `internal/template/provider/github.go`
+- `internal/template/provider/github_test.go`
+
+**Status**: COMPLETED
+
+```go
+func ParseGitHubURL(url string) (*model.TemplateRef, error)
+func (p *GitHubProvider) extractArchive(archivePath string) (string, error)
+```
+
+**Checklist**:
+
+- [x] Parse branch-only `/tree/<branch>` URLs as an empty template path with
+      `Ref=<branch>`.
+- [x] Trim trailing `.git` for all GitHub URL forms.
+- [x] Preserve documented ambiguity for slashed branch names; require explicit
+      `--ref` for those cases.
+- [x] Reject archive entries whose cleaned target escapes extraction root.
+- [x] Reject absolute symlink targets and symlink targets resolving outside the
+      extraction root.
+- [x] Add regression tests for MID-2 and provider-side MID-3.
+
+### 7. Documentation And Progress Tracking
+
+**Files**:
+
+- `docs/progress/verified-defect-remediation.md`
+- `design-docs/specs/architecture.md`
+- `design-docs/specs/command.md`
+- `impl-plans/active/verified-defect-remediation.md`
+- `impl-plans/PROGRESS.json`
+
+**Status**: COMPLETED
+
+**Checklist**:
+
+- [x] Add or update `docs/progress/verified-defect-remediation.md`.
+- [x] Record implemented sub-features, remaining work, design decisions, and
+      verification notes.
+- [x] Update this plan and `impl-plans/PROGRESS.json` task statuses during Step
+      6 implementation.
+- [x] Refresh design docs only if implementation reveals an accepted design
+      correction.
+
+### 8. Final Verification And Handoff
+
+**Files**:
+
+- All files changed by TASK-001 through TASK-007.
+
+**Status**: COMPLETED
+
+**Checklist**:
+
+- [x] Run `gofmt` on changed Go files.
+- [x] Run `go vet ./...`.
+- [x] Run `go build ./...`.
+- [x] Run `go test ./...`.
+- [x] Record command outcomes in the workflow result and progress log.
+
+---
+
+## Task Breakdown
+
+### TASK-001: Fix Update Transaction Safety And Hash Validation
+
+**Status**: Completed
+**Parallelizable**: Yes
+**Deliverables**: `internal/app/update.go`, `internal/app/update_cleanup.go`,
+`internal/app/manifest.go`, `internal/app/update_test.go`
+**Dependencies**: None
+
+**Description**:
+Implement HIGH-1 and MID-6 by validating update hashes and making update file
+generation/cleanup transactional before `.ign` config persistence.
+
+**Completion Criteria**:
+
+- [x] Update generation failure leaves previous `.ign` state unchanged.
+- [x] Cleanup partial failure still records successful writes and deletions in
+      `ign-files.json`.
+- [x] Malformed update template hash is rejected before persistence.
+- [x] Regression tests cover failure ordering and hash validation.
+
+### TASK-002: Add Atomic JSON Write Helper
+
+**Status**: Completed
+**Parallelizable**: Yes
+**Deliverables**: `internal/config/loader.go`, `internal/config/config_test.go`,
+`internal/app/template_update.go`, `internal/app/template_update_test.go`
+**Dependencies**: None
+
+**Description**:
+Implement HIGH-2 with one shared atomic write helper and route all four JSON
+persistence call sites through it.
+
+**Completion Criteria**:
+
+- [x] Helper writes temp file in target directory, fsyncs, renames, and cleans
+      up on failure.
+- [x] Existing save functions keep their public signatures and validation.
+- [x] Tests cover successful writes and failure cleanup behavior.
+
+### TASK-003: Fix Rewind Missing-Manifest Fallback
+
+**Status**: Completed
+**Parallelizable**: Yes
+**Deliverables**: `internal/app/rewind.go`, `internal/app/rewind_test.go`
+**Dependencies**: None
+
+**Description**:
+Implement HIGH-3 by deleting fallback candidates only when current content
+matches dry-run generated content.
+
+**Completion Criteria**:
+
+- [x] User-owned conflicting files are skipped.
+- [x] Matching generated files remain removable.
+- [x] Skipped files are visible in rewind result/reporting.
+
+### TASK-004: Fix CLI Error And Interactive Semantics
+
+**Status**: Completed
+**Parallelizable**: Yes
+**Deliverables**: `internal/cli/root.go`, `internal/cli/output.go`,
+`internal/cli/checkout.go`, `internal/cli/template.go`,
+`internal/cli/switch.go`, `internal/cli/prompt.go`, related CLI tests
+**Dependencies**: None
+
+**Description**:
+Implement HIGH-4, HIGH-5, MID-4, MID-5, and MID-7 in the CLI layer.
+
+**Completion Criteria**:
+
+- [x] Errors print under `--quiet`.
+- [x] Failures print once.
+- [x] Existing `.ign` checkout without `--force` returns non-zero.
+- [x] Template check returns errors instead of calling `os.Exit`.
+- [x] Switch supports `--var/-V` and does not create `.ign` before successful
+      variable handling.
+- [x] Invalid regex patterns fail before prompting.
+
+### TASK-005: Fix Template Parser And Generator Defects
+
+**Status**: Completed
+**Parallelizable**: Yes
+**Deliverables**: `internal/template/generator/processor.go`,
+`internal/template/parser/directive.go`, `internal/template/parser/include.go`,
+related generator/parser tests
+**Dependencies**: None
+
+**Description**:
+Implement HIGH-6, MID-1, and parser-side MID-3 containment hardening.
+
+**Completion Criteria**:
+
+- [x] Relative includes resolve from the including file.
+- [x] Same-line raw directives remain independent.
+- [x] Include containment uses `filepath.Rel` style checks.
+- [x] Regression tests cover each behavior.
+
+### TASK-006: Fix GitHub Provider URL And Extraction Safety
+
+**Status**: Completed
+**Parallelizable**: Yes
+**Deliverables**: `internal/template/provider/url.go`,
+`internal/template/provider/github.go`, related provider tests
+**Dependencies**: None
+
+**Description**:
+Implement MID-2 and provider-side MID-3 for GitHub template references and
+archive extraction.
+
+**Completion Criteria**:
+
+- [x] Branch-only `/tree/<branch>` URLs and trailing `.git` URLs parse
+      correctly.
+- [x] Escaping archive entries are rejected.
+- [x] Escaping symlink targets are rejected.
+- [x] Slashed branch ambiguity remains documented and is not guessed.
+
+### TASK-007: Update Progress Documentation
+
+**Status**: Completed
+**Parallelizable**: No
+**Deliverables**: `docs/progress/verified-defect-remediation.md`,
+`impl-plans/active/verified-defect-remediation.md`,
+`impl-plans/PROGRESS.json`
+**Dependencies**: TASK-001, TASK-002, TASK-003, TASK-004, TASK-005, TASK-006
+
+**Description**:
+Record implemented fixes, remaining work if any, and design decisions after the
+code changes are known.
+
+**Completion Criteria**:
+
+- [x] Progress file includes status, spec references, implemented items,
+      remaining items, design decisions, and notes.
+- [x] Plan and `PROGRESS.json` statuses match implementation state.
+
+### TASK-008: Run Required Verification
+
+**Status**: Completed
+**Parallelizable**: No
+**Deliverables**: verification command results in workflow output and progress
+log
+**Dependencies**: TASK-007
+
+**Description**:
+Run the required Go verification commands and record outcomes for review.
+
+**Completion Criteria**:
+
+- [x] `gofmt` completed for changed Go files.
+- [x] `go vet ./...` passes.
+- [x] `go build ./...` passes.
+- [x] `go test ./...` passes.
+
+---
+
+## Module Status
+
+| Module | File Path | Status | Tests |
+|--------|-----------|--------|-------|
+| Update transaction and hash validation | `internal/app/update.go` | COMPLETED | `internal/app/update_test.go` |
+| Atomic JSON persistence | `internal/config/loader.go`, `internal/app/template_update.go` | COMPLETED | `internal/config/config_test.go`, `internal/app/template_update_test.go` |
+| Rewind fallback ownership | `internal/app/rewind.go` | COMPLETED | `internal/app/rewind_test.go` |
+| CLI defect semantics | `internal/cli/*.go` targeted files | COMPLETED | `internal/cli/*_test.go` targeted tests |
+| Parser and include safety | `internal/template/parser/*.go`, `internal/template/generator/processor.go` | COMPLETED | parser/generator tests |
+| GitHub provider safety | `internal/template/provider/*.go` targeted files | COMPLETED | provider tests |
+| Progress tracking | `docs/progress/verified-defect-remediation.md` | COMPLETED | workflow review |
+
+## Dependencies
+
+| Feature | Depends On | Status |
+|---------|------------|--------|
+| TASK-001 Update transaction safety | None | COMPLETED |
+| TASK-002 Atomic JSON persistence | None | COMPLETED |
+| TASK-003 Rewind fallback ownership | None | COMPLETED |
+| TASK-004 CLI semantics | None | COMPLETED |
+| TASK-005 Parser/generator safety | None | COMPLETED |
+| TASK-006 GitHub provider safety | None | COMPLETED |
+| TASK-007 Progress documentation | TASK-001 through TASK-006 | COMPLETED |
+| TASK-008 Verification | TASK-007 | COMPLETED |
+
+## Completion Criteria
+
+- [x] All HIGH findings HIGH-1 through HIGH-6 are fixed.
+- [x] MID findings MID-1 through MID-7 are fixed unless Step 6 documents a
+      concrete implementation risk accepted by review.
+- [x] Regression tests cover every implemented finding.
+- [x] Existing behavior is preserved except where the findings define a defect.
+- [x] No new third-party dependencies are added.
+- [x] Public CLI behavior changes are limited to checkout existing-config
+      non-zero exit and `ign switch --var/-V`.
+- [x] `docs/progress/verified-defect-remediation.md` records implementation
+      status and verification notes.
+- [x] `gofmt`, `go vet ./...`, `go build ./...`, and `go test ./...` pass.
+
+## Progress Log
+
+### Session: 2026-07-12
+
+**Tasks Completed**: TASK-001 through TASK-008 implemented and verified.
+
+**Tasks In Progress**: None.
+
+**Blockers**: None.
+
+**Notes**: `gofmt`, `go vet ./...`, `go build ./...`, and `go test ./...`
+passed during Step 6.

--- a/impl-plans/ign-update-ref.md
+++ b/impl-plans/ign-update-ref.md
@@ -1,0 +1,507 @@
+# Add `ign update --ref <ref>` Implementation Plan
+
+**Status**: Completed
+**Design Reference**: `design-docs/specs/ign-update-ref.md`
+**Created**: 2026-07-13
+**Last Updated**: 2026-07-13
+
+## Feature Contract
+
+- Workflow ID: `design-and-implement-review-loop-feature-plan`
+- Workflow mode: `issue-resolution`
+- Issue reference: `workflowInput.issueBody FEATURE 2: 'ign update --ref <ref>' - retarget the tracked branch/tag`
+- Feature id: `ign-update-ref`
+- Fanout feature id: `ign-update-ref`
+- Implementation plan path: `impl-plans/ign-update-ref.md`
+- Target areas: `internal/cli`, `internal/app`
+- Codex agent references:
+  - `.agents/agents/go-coding.md`
+  - `.agents/agents/go-check-and-test-after-modify.md`
+
+## Design Document Reference
+
+**Source**: `design-docs/specs/ign-update-ref.md`
+
+### Summary
+
+Add `ign update --ref <ref>` so project users can retarget the template branch,
+tag, or commit stored in `.ign/ign.json` without invoking destructive
+`ign switch` behavior. The requested ref must use the existing update flow,
+compose with dry-run and overwrite protections, validate before provider fetch,
+persist after successful non-dry-run completion, and preserve current behavior
+when `--ref` is omitted.
+
+### Scope
+
+**Included**:
+
+- Add `--ref` and `-r` parsing to `internal/cli/update.go`.
+- Thread the requested ref through `app.UpdateOptions` to `PrepareUpdate`.
+- Validate refs before network/provider fetch in CLI and defensively in app.
+- Fetch the configured template URL/path at the requested ref.
+- Persist `.ign/ign.json.template.ref` and `.ign/ign.json.hash`
+  transactionally after successful non-dry-run completion.
+- Persist identical-content ref retargets without regenerating project files.
+- Add unit tests, integration tests, README command documentation, and feature
+  progress documentation.
+
+**Excluded**:
+
+- The separate `ign vars` command.
+- Destructive `ign switch` or `ign rewind` behavior changes.
+- New third-party dependencies.
+- Provider redesign beyond passing the requested ref into the existing fetch
+  path.
+
+## Modules
+
+### 1. Shared Git Ref Validation
+
+#### `internal/app/ref_validation.go`
+
+**Status**: Completed
+
+```go
+func ValidateGitRef(ref string) error
+```
+
+**Checklist**:
+
+- [x] Move neutral git ref validation into `internal/app` or another non-CLI
+      package accessible to app callers.
+- [x] Keep CLI update validation before `app.PrepareUpdate`.
+- [x] Keep app validation before provider resolve/fetch.
+- [x] Cover branches, tags, commit SHAs, empty refs, and malformed refs.
+
+### 2. CLI Update Command
+
+#### `internal/cli/update.go`
+
+**Status**: Completed
+
+```go
+var updateRef string
+
+func runUpdate(cmd *cobra.Command, args []string) error
+func shouldRegenerate(hashChanged, force, overwrite bool) bool
+func shouldCompleteUpdate(prep *app.PrepareUpdateResult, force bool, overwrite bool) bool
+```
+
+**Checklist**:
+
+- [x] Register `--ref` with shorthand `-r`.
+- [x] Reset `updateRef` in tests alongside existing update flag globals.
+- [x] Validate non-empty `--ref` before update preparation.
+- [x] Pass `TargetRef` through `app.UpdateOptions`.
+- [x] Show the effective requested ref when `--ref` is supplied, including
+      explicit `main`.
+- [x] Avoid the unchanged-template early return when only the tracked ref
+      changed.
+- [x] Print an identical-content note when the requested ref resolves to the
+      same template hash.
+
+### 3. Update Preparation
+
+#### `internal/app/update.go`
+
+**Status**: Completed
+
+```go
+type UpdateOptions struct {
+    OutputDir     string
+    Overwrite     bool
+    OverwriteMode generator.OverwriteMode
+    DryRun        bool
+    Verbose       bool
+    GitHubToken   string
+    TargetRef     string
+}
+
+type PrepareUpdateResult struct {
+    Template             *model.Template
+    IgnJson              *model.IgnJson
+    ExistingVars         map[string]interface{}
+    NewVars              []string
+    RemovedVars          []string
+    CurrentHash          string
+    NewHash              string
+    HashChanged          bool
+    IgnConfigPath        string
+    IgnVarPath           string
+    IgnConfig            *model.IgnConfig
+    PreviousRef          string
+    RequestedRef         string
+    EffectiveRef         string
+    RefOverrideRequested bool
+    RefChanged           bool
+}
+```
+
+**Checklist**:
+
+- [x] Add `TargetRef` to `UpdateOptions`.
+- [x] Snapshot the stored ref before applying overrides.
+- [x] Validate `TargetRef` before provider work.
+- [x] Override only `Template.Ref`, preserving stored URL and path.
+- [x] Fetch and compare hashes using the requested ref.
+- [x] Populate ref metadata for CLI messaging and completion decisions.
+- [x] Preserve no-`--ref` behavior.
+
+### 4. Completion And Artifact Persistence
+
+#### `internal/app/update.go`
+
+**Status**: Completed
+
+```go
+type UpdateResult struct {
+    HashChanged          bool
+    NewVariables         []string
+    RemovedVariables     []string
+    FilesCreated         int
+    FilesSkipped         int
+    FilesOverwritten     int
+    FilesDeleted         int
+    Errors               []error
+    Files                []string
+    DeletedFiles         []string
+    DryRunFiles          []DryRunFile
+    Directories          []string
+    RefChanged           bool
+    RefOverrideRequested bool
+}
+
+func CompleteUpdate(ctx context.Context, opts CompleteUpdateOptions) (*UpdateResult, error)
+func saveCompleteUpdateArtifacts(prep *PrepareUpdateResult, rawVars map[string]interface{}, genResult *generator.GenerateResult, removedManagedFiles *cleanupRemovedManagedFilesResult, rollback *checkoutGenerationRollback) error
+func saveCompleteUpdateConfigOnlyArtifacts(prep *PrepareUpdateResult, rawVars map[string]interface{}) error
+```
+
+**Checklist**:
+
+- [x] Persist `IgnConfig.Hash = NewHash` and
+      `IgnConfig.Template.Ref = RequestedRef` after successful non-dry-run
+      completion.
+- [x] Keep generation and stale-file cleanup before `.ign` artifact writes.
+- [x] Use rollback snapshots for `.ign/ign.json`, `.ign/ign-var.json`, and
+      `.ign/ign-files.json`.
+- [x] Add a config-only completion path for `RefChanged && !HashChanged` when
+      no force or overwrite regeneration is requested.
+- [x] Avoid project-file regeneration for identical-content ref retargets.
+- [x] Leave all artifacts unchanged during dry runs.
+- [x] Restore the previous ref and hash on artifact-save failure.
+
+### 5. Tests
+
+#### `internal/cli/update_test.go`
+#### `internal/app/update_test.go`
+#### `test/integration/update_ref_test.go`
+
+**Status**: Completed
+
+```go
+func TestUpdateCmd_FlagRegistration(t *testing.T)
+func TestUpdateCmd_FlagParsing(t *testing.T)
+func TestPrepareUpdate_TargetRefOverridesStoredRef(t *testing.T)
+func TestPrepareUpdate_InvalidTargetRefFailsBeforeFetch(t *testing.T)
+func TestCompleteUpdate_IdenticalHashRefRetargetPersistsConfigOnly(t *testing.T)
+func TestCompleteUpdate_DryRunRefRetargetDoesNotPersist(t *testing.T)
+func TestCompleteUpdate_SaveFailureRollsBackPreviousRef(t *testing.T)
+func TestUpdateRefRetargetsTemplateAndPersistsRef(t *testing.T)
+func TestUpdateRefIdenticalContentPersistsRefWithoutRewritingFiles(t *testing.T)
+func TestUpdateRefDryRunDoesNotPersistRef(t *testing.T)
+func TestUpdateRefOverwriteKeepsOverwriteProtections(t *testing.T)
+```
+
+**Checklist**:
+
+- [x] Cover long and short ref flag registration and parsing.
+- [x] Assert invalid refs fail before app update execution.
+- [x] Assert requested ref overrides stored ref while preserving URL/path.
+- [x] Assert identical-hash ref retarget persists only configuration.
+- [x] Assert dry-run leaves `.ign` artifacts unchanged.
+- [x] Assert artifact save failures roll back previous ref and hash.
+- [x] Assert overwrite protections still apply with `--ref --overwrite --yes`.
+
+### 6. Documentation And Progress
+
+#### `README.md`
+#### `docs/progress/ign-update-ref.md`
+
+**Status**: Completed
+
+```markdown
+ign update --ref v2.0.0
+ign update --ref v2.0.0 --dry-run
+ign update --ref v2.0.0 --overwrite --yes
+```
+
+**Checklist**:
+
+- [x] Document `ign update --ref <ref>` and `-r` in README command examples
+      and flags.
+- [x] Document non-destructive retargeting behavior.
+- [x] Document identical-content ref pin persistence on non-dry-run success.
+- [x] Document that dry-run leaves the stored ref unchanged.
+- [x] Add `docs/progress/ign-update-ref.md` with status, spec reference,
+      implemented work, remaining work, design decisions, and notes.
+
+## Module Status
+
+| Module | File Path | Status | Tests |
+|--------|-----------|--------|-------|
+| Shared git ref validation | `internal/app/ref_validation.go` | Completed | `internal/app/update_test.go` |
+| CLI update command | `internal/cli/update.go` | Completed | `internal/cli/update_test.go` |
+| Update preparation | `internal/app/update.go` | Completed | `internal/app/update_test.go` |
+| Completion persistence | `internal/app/update.go` | Completed | `internal/app/update_test.go` |
+| Integration behavior | `test/integration/update_ref_test.go` | Completed | `go test ./test/integration` |
+| Documentation | `README.md`, `docs/progress/ign-update-ref.md` | Completed | review + `go test ./...` |
+
+## Task Breakdown
+
+### TASK-001: Centralize Git Ref Validation
+
+**Status**: Completed
+**Parallelizable**: Yes
+**Deliverables**: `internal/app/ref_validation.go`, `internal/app/update_test.go`, `internal/cli/flags.go`
+**Dependencies**: None
+
+**Description**:
+Create app-accessible git ref validation and keep CLI validation aligned with
+the same rule before provider or network access.
+
+**Completion Criteria**:
+
+- [x] `app.ValidateGitRef` or equivalent rejects empty and malformed refs.
+- [x] CLI can validate refs before invoking `app.PrepareUpdate`.
+- [x] Tests cover valid branch, tag, SHA, and invalid inputs.
+
+### TASK-002: Add CLI `--ref` Flag
+
+**Status**: Completed
+**Parallelizable**: No
+**Deliverables**: `internal/cli/update.go`, `internal/cli/update_test.go`
+**Dependencies**: TASK-001
+
+**Description**:
+Register `--ref`/`-r`, parse and validate it, pass it through
+`app.UpdateOptions.TargetRef`, and adjust output plus early-return decisions.
+
+**Completion Criteria**:
+
+- [x] `ign update --ref <ref>` parses successfully.
+- [x] `ign update -r <ref>` parses successfully.
+- [x] Invalid refs fail before provider fetch.
+- [x] Ref-only changes do not trigger the unchanged-template early return.
+
+### TASK-003: Implement PrepareUpdate Ref Override
+
+**Status**: Completed
+**Parallelizable**: No
+**Deliverables**: `internal/app/update.go`, `internal/app/update_test.go`
+**Dependencies**: TASK-001
+
+**Description**:
+Extend update preparation to validate and apply `TargetRef` while retaining the
+stored template URL and path.
+
+**Completion Criteria**:
+
+- [x] `UpdateOptions.TargetRef` exists.
+- [x] `PrepareUpdateResult` exposes previous/requested/effective ref metadata.
+- [x] Target ref is used for provider fetch and hash comparison.
+- [x] No-`--ref` update behavior remains unchanged.
+
+### TASK-004: Add Ref-Only Transactional Completion
+
+**Status**: Completed
+**Parallelizable**: No
+**Deliverables**: `internal/app/update.go`, `internal/app/update_test.go`
+**Dependencies**: TASK-003
+
+**Description**:
+Persist requested refs through rollback-safe update artifact writes, including
+identical-content retargets that should not rewrite project files.
+
+**Completion Criteria**:
+
+- [x] Successful non-dry-run update writes requested ref and new hash.
+- [x] Identical-hash ref retarget persists config without requiring overwrite
+      or force.
+- [x] Dry-run leaves `.ign` artifacts unchanged.
+- [x] Save failure restores previous ref and hash.
+
+### TASK-005: Preserve Existing Update Flag Compositions
+
+**Status**: Completed
+**Parallelizable**: No
+**Deliverables**: `internal/cli/update.go`, `internal/app/update.go`, `internal/app/update_test.go`
+**Dependencies**: TASK-002, TASK-004
+
+**Description**:
+Ensure `--ref` composes with `--dry-run`, `--overwrite`, `--overwrite-all`,
+`--yes`, and `--force` without regressing current update behavior.
+
+**Completion Criteria**:
+
+- [x] `--dry-run --ref` previews against requested ref and writes nothing.
+- [x] `--overwrite --yes --ref` keeps selective overwrite behavior and
+      `.ign-overwrite-ignore` protections.
+- [x] `--force --ref` regenerates and persists the requested ref.
+- [x] Existing update tests without `--ref` continue to pass.
+
+### TASK-006: Add Integration Coverage
+
+**Status**: Completed
+**Parallelizable**: No
+**Deliverables**: `test/integration/update_ref_test.go`, integration fixtures under `test/testdata`
+**Dependencies**: TASK-004
+
+**Description**:
+Add end-to-end coverage for ref retargeting, identical-content pin updates,
+dry-run non-persistence, and overwrite protections.
+
+**Completion Criteria**:
+
+- [x] Integration test verifies generated files and stored ref after retarget.
+- [x] Integration test verifies identical-content retarget avoids project-file
+      rewrites while persisting config.
+- [x] Integration test verifies dry-run leaves config unchanged.
+- [x] Integration test verifies overwrite protections still apply.
+
+### TASK-007: Refresh User Documentation And Progress
+
+**Status**: Completed
+**Parallelizable**: Yes
+**Deliverables**: `README.md`, `docs/progress/ign-update-ref.md`
+**Dependencies**: None
+
+**Description**:
+Document the new command behavior and maintain feature progress tracking.
+
+**Completion Criteria**:
+
+- [x] README documents `--ref` and `-r` on `ign update`.
+- [x] README includes dry-run and overwrite examples.
+- [x] Progress file records implemented/remaining work and design decisions.
+
+### TASK-008: Run Final Verification
+
+**Status**: Completed
+**Parallelizable**: No
+**Deliverables**: verification logs
+**Dependencies**: TASK-005, TASK-006, TASK-007
+
+**Description**:
+Run formatting, static checks, build, and full tests after implementation.
+
+**Completion Criteria**:
+
+- [x] `gofmt -w <modified-go-files>` completed.
+- [x] `go vet ./...` passes.
+- [x] `go build ./...` passes.
+- [x] `go test ./...` passes.
+
+## Dependencies
+
+| Feature | Depends On | Status |
+|---------|------------|--------|
+| TASK-001 validation | None | COMPLETED |
+| TASK-002 CLI flag | TASK-001 | COMPLETED |
+| TASK-003 prepare override | TASK-001 | COMPLETED |
+| TASK-004 persistence | TASK-003 | COMPLETED |
+| TASK-005 flag compositions | TASK-002, TASK-004 | COMPLETED |
+| TASK-006 integration tests | TASK-004 | COMPLETED |
+| TASK-007 docs and progress | None | COMPLETED |
+| TASK-008 final verification | TASK-005, TASK-006, TASK-007 | COMPLETED |
+
+## Parallelizable Tasks
+
+- `TASK-001`: shared validation.
+- `TASK-007`: README and progress documentation.
+- After `TASK-001`, `TASK-002` and `TASK-003` can proceed in parallel if
+  coordinated to avoid conflicting edits in `internal/app/update.go`.
+- After `TASK-004`, `TASK-006` can proceed while `TASK-005` finishes CLI/app
+  composition polish, if integration fixtures do not depend on unresolved CLI
+  output strings.
+
+## Completion Criteria
+
+- [x] `ign update --ref <ref>` and `ign update -r <ref>` are available.
+- [x] Requested refs are validated before provider fetch in CLI and app paths.
+- [x] Retargeting preserves configured template URL/path and changes only ref.
+- [x] Existing update behavior is unchanged when `--ref` is omitted.
+- [x] `--dry-run --ref` writes no `.ign` artifacts.
+- [x] Successful non-dry-run retarget persists the requested ref even when the
+      content hash is unchanged.
+- [x] Rollback restores previous ref/hash on artifact-save failure.
+- [x] Existing overwrite, overwrite-all, yes, and force protections still apply.
+- [x] README and `docs/progress/ign-update-ref.md` are updated.
+- [x] Required verification commands pass.
+
+## Verification
+
+Required commands:
+
+```bash
+gofmt -w <modified-go-files>
+go vet ./...
+go build ./...
+go test ./...
+```
+
+Focused commands during implementation:
+
+```bash
+go test ./internal/cli ./internal/app
+go test ./test/integration
+```
+
+## Addressed Feedback
+
+- Accepted design review finding: the design's `-r` shorthand is treated as an
+  accepted compatible extension because checkout and switch already use `-r`
+  for refs.
+- Scoped this plan to `ign-update-ref`; it intentionally excludes the separate
+  `ign vars` feature.
+- Called out rollback-safe identical-content retargeting because design review
+  identified it as the primary implementation risk.
+- Kept validation explicit in both CLI and app paths to avoid non-CLI caller
+  drift.
+
+## Risks
+
+- A config-only identical-content retarget can regress rollback safety if it
+  bypasses existing artifact snapshot helpers.
+- Ref validation can drift if CLI and app validation are not centralized.
+- Local integration fixtures may not fully model remote git ref switching, so
+  tests should separately assert persisted config and provider fetch behavior.
+- Existing dirty planning files in the workspace may be unrelated; implementation
+  should avoid reverting or depending on unrelated changes.
+
+## Progress Log
+
+### Session: 2026-07-13
+
+**Tasks Completed**: TASK-001 through TASK-008 implemented.
+**Tasks In Progress**: Verification running in Step 6.
+**Blockers**: None.
+**Notes**: Added centralized validation, CLI flag handling, target-ref update
+preparation, identical-content config-only persistence, tests, README
+documentation, and progress tracking.
+
+### Session: 2026-07-13 Step 7 Remediation
+
+**Tasks Completed**: Strengthened TASK-006 integration coverage.
+**Tasks In Progress**: None.
+**Blockers**: None.
+**Notes**: Added compiled CLI integration cases for changed-template generated
+file updates, identical-content no-rewrite ref persistence, dry-run preview and
+non-persistence, and selective overwrite protection with `.ign-overwrite-ignore`.
+
+## Related Plans
+
+- **Previous**: None.
+- **Next**: None.
+- **Depends On**: `design-docs/specs/ign-update-ref.md`.
+- **Related Historical Plans**: `impl-plans/ign-update-ref-flag.md`,
+  `impl-plans/active/update-ref.md`.

--- a/impl-plans/ign-vars.md
+++ b/impl-plans/ign-vars.md
@@ -1,0 +1,430 @@
+# Add `ign vars` Command Implementation Plan
+
+**Status**: Completed
+**Design Reference**: `design-docs/specs/ign-vars.md`
+**Created**: 2026-07-13
+**Last Updated**: 2026-07-13
+
+## Feature Contract
+
+- Workflow mode: `issue-resolution`
+- Issue reference: `workflowInput.issueBody FEATURE 1: 'ign vars' - inspect template variables and current values`
+- Feature id: `ign-vars`
+- Fanout feature ids: `ign-vars`
+- Implementation plan path: `impl-plans/ign-vars.md`
+- Target areas: `internal/cli`, `internal/app`, `internal/config`, `internal/template`
+- Codex agent references:
+  - `.agents/agents/go-coding.md`
+  - `.agents/agents/go-check-and-test-after-modify.md`
+
+## Design Document Reference
+
+**Source**: `design-docs/specs/ign-vars.md`
+
+### Summary
+
+Implement a read-only `ign vars` command that displays template variable
+declarations merged with current `.ign/ign-var.json` values. The command must
+support table output, `--json`, `--unset`, and `--json --unset`, keep JSON
+stdout script-safe, degrade to local-only values when template declarations
+cannot be fetched, and return exit code `1` only when known required variables
+are unset.
+
+### Scope
+
+**Included**:
+
+- New app-layer variable inspection query in `internal/app/vars.go`.
+- Shared template declaration fetch helper only if needed to reuse update or
+  checkout provider behavior without update-only mutation or hash validation.
+- New CLI command in `internal/cli/vars.go`, registered from `internal/cli/root.go`.
+- Unit tests for app merge semantics and CLI output/exit behavior.
+- Integration tests under `test/integration`.
+- README command documentation for `ign vars`, `--json`, and `--unset`.
+
+**Excluded**:
+
+- The separate `ign update --ref` feature.
+- Any mutation of `.ign/ign.json`, `.ign/ign-var.json`, `.ign/ign-files.json`,
+  template hashes, or generated project files.
+- New third-party dependencies.
+- Checkout/update prompting or generation readiness validation.
+
+## Modules
+
+### 1. App Vars Query
+
+#### `internal/app/vars.go`
+
+**Status**: Completed
+
+```go
+type VarsOptions struct {
+    OutputDir   string
+    UnsetOnly   bool
+    GitHubToken string
+}
+
+type VarsResult struct {
+    DeclarationsAvailable bool
+    Rows                  []VarsRow
+    UnsetCount            int
+    RequiredUnsetCount    int
+    DeclarationError      error
+}
+
+type VarsRow struct {
+    Name        string
+    Type        string
+    Required    bool
+    Default     interface{}
+    Current     interface{}
+    HasCurrent  bool
+    Description string
+    Unset       bool
+    Declared    bool
+}
+
+func InspectVars(ctx context.Context, opts VarsOptions) (*VarsResult, error)
+func IsRequiredUnset(err error) bool
+```
+
+**Checklist**:
+
+- [x] Load `.ign/ign.json` and `.ign/ign-var.json` with existing config loaders.
+- [x] Fetch configured template declarations using stored URL, ref, and path.
+- [x] Merge declarations and current values without applying defaults as current values.
+- [x] Treat absent keys as unset; treat `nil`, `false`, `0`, and `""` as current when present.
+- [x] Include local-only rows for values not declared by the template.
+- [x] Sort rows by variable name.
+- [x] Return local-only rows and a non-fatal declaration error when fetch fails.
+- [x] Never mutate config, variables, manifests, hashes, or generated files.
+
+### 2. Template Declaration Fetch Reuse
+
+#### `internal/app/template_fetch.go` or `internal/app/update.go`
+
+**Status**: Completed
+
+```go
+type trackedTemplateFetchOptions struct {
+    Source      model.TemplateSource
+    GitHubToken string
+}
+
+func fetchTrackedTemplate(ctx context.Context, opts trackedTemplateFetchOptions) (*model.Template, error)
+```
+
+**Checklist**:
+
+- [x] Extract provider resolution/fetch behavior only if current `PrepareUpdate` code cannot be reused safely.
+- [x] Preserve URL normalization, provider creation, stored ref, and stored path semantics.
+- [x] Avoid update-only hash validation, variable prompting, generation, or artifact writes.
+- [x] Keep existing `PrepareUpdate` behavior unchanged if it is refactored to call this helper.
+- [x] Unit test stored ref/path propagation when extraction occurs.
+
+### 3. CLI Vars Command
+
+#### `internal/cli/vars.go`
+#### `internal/cli/root.go`
+
+**Status**: Completed
+
+```go
+var varsJSON bool
+var varsUnset bool
+
+func runVars(cmd *cobra.Command, args []string) error
+func printVarsTable(result *app.VarsResult)
+func printVarsJSON(result *app.VarsResult) error
+func warnVarsDeclarationsUnavailable(err error)
+```
+
+**Checklist**:
+
+- [x] Register `ign vars` with `--json` and `--unset`.
+- [x] Respect global `--quiet` by suppressing normal output and warnings.
+- [x] Respect `--no-color` by using existing output behavior and avoiding new colored table content.
+- [x] Keep declaration-unavailable warnings off stdout in JSON mode.
+- [x] Return a non-zero exit for required unset variables without duplicate Cobra error output.
+- [x] Print table columns `NAME`, `TYPE`, `REQUIRED`, `DEFAULT`, `CURRENT`, `DESCRIPTION`.
+- [x] Print JSON with declaration availability, rows, `unset_count`, and `required_unset_count`.
+
+### 4. Unit Tests
+
+#### `internal/app/vars_test.go`
+#### `internal/cli/vars_test.go`
+
+**Status**: Completed
+
+```go
+func TestInspectVars_MergesDeclarationsAndCurrentValues(t *testing.T)
+func TestInspectVars_UnsetSemanticsUseKeyPresence(t *testing.T)
+func TestInspectVars_FetchFailureReturnsLocalOnlyRows(t *testing.T)
+func TestVarsCmd_TableOutput(t *testing.T)
+func TestVarsCmd_JSONOutputIsScriptSafe(t *testing.T)
+func TestVarsCmd_UnsetRequiredReturnsExitOne(t *testing.T)
+```
+
+**Checklist**:
+
+- [x] Cover deterministic sorting and local-only rows.
+- [x] Cover required unset counts and unset-only filtering.
+- [x] Cover missing `.ign` errors matching update/rewind style.
+- [x] Cover quiet suppression.
+- [x] Cover warning routing for JSON mode.
+- [x] Cover command registration and flag parsing.
+
+### 5. Integration Tests
+
+#### `test/integration/vars_test.go`
+
+**Status**: Completed
+
+```go
+func TestVarsCommandListsTemplateVariables(t *testing.T)
+func TestVarsCommandJSONOutput(t *testing.T)
+func TestVarsCommandUnsetSatisfiedVariablesExitZero(t *testing.T)
+func TestVarsCommandUnsetRequiredMissingExitOne(t *testing.T)
+```
+
+**Checklist**:
+
+- [x] Seed or checkout a local fixture template with declared variables.
+- [x] Verify table output columns and current values.
+- [x] Verify JSON output parses and has expected row/count fields.
+- [x] Verify `--unset` filters rows.
+- [x] Verify required missing variables return exit code `1`.
+- [x] Verify no generated files or `.ign` artifacts are mutated by `ign vars`.
+
+### 6. README Command Documentation
+
+#### `README.md`
+
+**Status**: Completed
+
+```text
+ign vars
+ign vars --json
+ign vars --unset
+```
+
+**Checklist**:
+
+- [x] Add `ign vars` to command documentation.
+- [x] Document table columns.
+- [x] Document JSON scripting mode.
+- [x] Document `--unset` CI gate behavior and required-unset exit code `1`.
+- [x] Document local-only fallback when template declarations are unavailable.
+
+## Module Status
+
+| Module | File Path | Status | Tests |
+|--------|-----------|--------|-------|
+| App vars query | `internal/app/vars.go` | Completed | `internal/app/vars_test.go` |
+| Template declaration fetch reuse | `internal/app/template_fetch.go` | Completed | `internal/app/vars_test.go`, `internal/app/update_test.go` |
+| CLI vars command | `internal/cli/vars.go`, `internal/cli/root.go` | Completed | `internal/cli/vars_test.go` |
+| Integration tests | `test/integration/vars_test.go` | Completed | `go test ./test/integration` |
+| README docs | `README.md` | Completed | manual docs review |
+
+## Dependencies
+
+| Feature | Depends On | Status |
+|---------|------------|--------|
+| `ign-vars` | Accepted design `design-docs/specs/ign-vars.md` | Completed |
+| App vars query | Existing config loaders and provider/template models | Completed |
+| CLI vars command | App vars query | Completed |
+| Unit tests | App vars query and CLI command | Completed |
+| Integration tests | CLI vars command and fixtures | Completed |
+| README docs | Final CLI behavior | Completed |
+
+## Task Breakdown
+
+### TASK-001: Implement App-Layer Vars Inspection
+
+**Status**: Completed
+**Parallelizable**: Yes
+**Deliverables**: `internal/app/vars.go`, `internal/app/vars_test.go`
+**Dependencies**: None
+
+**Description**:
+Add the read-only app API that loads project config/current variables, fetches
+template declarations, merges rows, computes unset counts, and exposes
+declaration fetch failures as non-fatal result state.
+
+**Completion Criteria**:
+
+- [x] Rows include declared metadata, current values, `HasCurrent`, `Unset`, and `Declared`.
+- [x] Missing current values are based on key absence only.
+- [x] Rows and counts are deterministic.
+- [x] Fetch failures return local-only rows and do not fail normal listing.
+- [x] Missing `.ign` config returns an error consistent with update/rewind behavior.
+
+### TASK-002: Extract Safe Template Fetch Helper If Needed
+
+**Status**: Completed
+**Parallelizable**: Yes
+**Deliverables**: `internal/app/template_fetch.go` or focused updates in `internal/app/update.go`, tests covering ref/path behavior
+**Dependencies**: None
+
+**Description**:
+Share the provider resolution and fetch path needed by `ign vars` without
+pulling in update-only hash comparison, validation, or artifact mutation.
+
+**Completion Criteria**:
+
+- [x] Stored template URL, ref, and path are honored.
+- [x] Existing update tests still pass if `PrepareUpdate` is refactored.
+- [x] `ign vars` can fetch declarations without requiring template hash validation.
+
+### TASK-003: Add CLI Command And Output Formatting
+
+**Status**: Completed
+**Parallelizable**: No
+**Deliverables**: `internal/cli/vars.go`, `internal/cli/root.go`, `internal/cli/vars_test.go`
+**Dependencies**: TASK-001
+
+**Description**:
+Register `ign vars`, parse `--json` and `--unset`, call the app query, and
+format table or JSON output while preserving quiet/no-color behavior and JSON
+stdout safety.
+
+**Completion Criteria**:
+
+- [x] `ign vars`, `ign vars --json`, `ign vars --unset`, and `ign vars --json --unset` work.
+- [x] Table output includes all required columns.
+- [x] JSON output is valid JSON with no warning text on stdout.
+- [x] Required unset variables produce process exit code `1` without duplicate error printing.
+
+### TASK-004: Add Integration Coverage
+
+**Status**: Completed
+**Parallelizable**: No
+**Deliverables**: `test/integration/vars_test.go`, fixture updates if needed
+**Dependencies**: TASK-003
+
+**Description**:
+Exercise the compiled command against local fixture projects so command
+behavior, exit codes, JSON output, and read-only guarantees are verified end to
+end.
+
+**Completion Criteria**:
+
+- [x] Integration tests cover table output, JSON output, unset-only output, and required-unset exit `1`.
+- [x] Tests verify `ign vars` does not modify `.ign` artifacts or generated files.
+- [x] Fixture changes are minimal and reusable by existing integration helpers.
+
+### TASK-005: Refresh README Command Documentation
+
+**Status**: Completed
+**Parallelizable**: No
+**Deliverables**: `README.md`
+**Dependencies**: TASK-003
+
+**Description**:
+Document the final command surface and scripting behavior in the README command
+section.
+
+**Completion Criteria**:
+
+- [x] README lists `ign vars`.
+- [x] README documents `--json` and `--unset`.
+- [x] README states required-unset `--unset` exits with code `1`.
+- [x] README states local-only fallback when declarations cannot be fetched.
+
+### TASK-006: Run Verification And Record Progress
+
+**Status**: Completed
+**Parallelizable**: No
+**Deliverables**: verification output, `docs/progress/non-interactive-template-variables.md` or feature-specific progress file if implementation workflow updates progress docs
+**Dependencies**: TASK-001, TASK-002, TASK-003, TASK-004, TASK-005
+
+**Description**:
+Run formatting, static checks, build, tests, and update progress tracking as
+required by the implementation workflow after code and documentation changes.
+
+**Completion Criteria**:
+
+- [x] `gofmt` has been applied to changed Go files.
+- [x] `go vet ./...` passes.
+- [x] `go build ./...` passes.
+- [x] `go test ./...` passes.
+- [x] Progress tracking documents reflect completed implementation work.
+
+## Parallelizable Tasks
+
+- `TASK-001` and `TASK-002` can start in parallel if the fetch helper boundary
+  is coordinated before merging.
+- `TASK-003` depends on `TASK-001`.
+- `TASK-004` and `TASK-005` both depend on `TASK-003`; documentation can be
+  drafted while integration tests are being added after the final CLI behavior
+  is stable.
+- `TASK-006` depends on all implementation, test, and documentation tasks.
+
+## Verification
+
+Required commands:
+
+```bash
+gofmt
+go vet ./...
+go build ./...
+go test ./...
+```
+
+Focused checks:
+
+```bash
+go test ./internal/app -run 'TestInspectVars'
+go test ./internal/cli -run 'TestVarsCmd|TestVars'
+go test ./test/integration -run 'TestVarsCommand'
+```
+
+## Completion Criteria
+
+- [x] `ign vars` is registered and documented.
+- [x] `ign vars` prints table rows with `NAME`, `TYPE`, `REQUIRED`, `DEFAULT`, `CURRENT`, and `DESCRIPTION`.
+- [x] `ign vars --json` prints valid JSON only on stdout.
+- [x] `ign vars --unset` filters unset variables and exits `1` only for known required unset variables.
+- [x] Offline or failed declaration fetch produces local-only rows and a non-fatal warning outside JSON stdout.
+- [x] The command is read-only for `.ign` artifacts, hashes, manifests, and generated files.
+- [x] Unit and integration tests cover app merge semantics, CLI output, quiet behavior, JSON safety, exit codes, and read-only behavior.
+- [x] `README.md` command documentation is refreshed.
+- [x] `gofmt`, `go vet ./...`, `go build ./...`, and `go test ./...` pass.
+
+## Addressed Feedback
+
+- Design review accepted `design-docs/specs/ign-vars.md` and requested planning
+  for `impl-plans/ign-vars.md`.
+- JSON stdout safety is explicit in CLI tasks and tests.
+- Read-only behavior is explicit in app tasks, integration tests, and completion criteria.
+- Provider fetch reuse is isolated so update-only hash validation and mutation
+  flow do not leak into `ign vars`.
+
+## Risks
+
+- Fetch reuse may require refactoring `PrepareUpdate`; this must not regress
+  update behavior or require template hash validation for read-only inspection.
+- Existing warning helpers write to stdout, so JSON mode needs stderr-specific
+  warning handling or suppression.
+- Required-unset exit handling needs a sentinel or typed error path that
+  preserves exit code `1` without noisy duplicate error output.
+- Offline fallback cannot detect missing required variables when declarations
+  are unavailable.
+- Global CLI flag state in tests may need careful reset between command tests.
+
+## Progress Log
+
+### Session: 2026-07-13 00:39 JST
+
+**Tasks Completed**: TASK-001 through TASK-006 implemented.
+**Tasks In Progress**: Verification running in Step 6.
+**Blockers**: None.
+**Notes**: Added app inspection, shared fetch reuse, CLI output, tests,
+README documentation, and progress tracking in issue-resolution mode.
+
+## Related Plans
+
+- **Sibling**: `impl-plans/ign-update-ref-flag.md` covers the separate fanout
+  feature `ign-update-ref`.
+- **Depends On**: `design-docs/specs/ign-vars.md`.

--- a/internal/app/ref_validation.go
+++ b/internal/app/ref_validation.go
@@ -1,0 +1,56 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// ValidateGitRef validates a git branch, tag, or commit reference.
+func ValidateGitRef(ref string) error {
+	if ref == "" {
+		return fmt.Errorf("git reference cannot be empty")
+	}
+	if strings.TrimSpace(ref) != ref {
+		return fmt.Errorf("invalid git reference %q: leading or trailing whitespace is not allowed", ref)
+	}
+	if strings.HasPrefix(ref, "/") || strings.HasSuffix(ref, "/") {
+		return fmt.Errorf("invalid git reference %q: cannot start or end with '/'", ref)
+	}
+	if strings.HasSuffix(ref, ".") {
+		return fmt.Errorf("invalid git reference %q: cannot end with '.'", ref)
+	}
+	if strings.Contains(ref, "..") {
+		return fmt.Errorf("invalid git reference %q: cannot contain '..'", ref)
+	}
+	if strings.Contains(ref, "//") {
+		return fmt.Errorf("invalid git reference %q: cannot contain '//'", ref)
+	}
+	if strings.Contains(ref, "@{") {
+		return fmt.Errorf("invalid git reference %q: cannot contain '@{'", ref)
+	}
+	if strings.HasSuffix(ref, ".lock") || strings.Contains(ref, ".lock/") {
+		return fmt.Errorf("invalid git reference %q: cannot contain a .lock path component", ref)
+	}
+
+	for _, r := range ref {
+		if unicode.IsSpace(r) || unicode.IsControl(r) {
+			return fmt.Errorf("invalid git reference %q: whitespace and control characters are not allowed", ref)
+		}
+		switch r {
+		case '~', '^', ':', '?', '*', '[', '\\':
+			return fmt.Errorf("invalid git reference %q: contains invalid character %q", ref, r)
+		}
+	}
+
+	for _, part := range strings.Split(ref, "/") {
+		if part == "" {
+			return fmt.Errorf("invalid git reference %q: empty path component", ref)
+		}
+		if strings.HasPrefix(part, ".") {
+			return fmt.Errorf("invalid git reference %q: path components cannot start with '.'", ref)
+		}
+	}
+
+	return nil
+}

--- a/internal/app/rewind.go
+++ b/internal/app/rewind.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -28,9 +29,11 @@ type RewindOptions struct {
 type RewindResult struct {
 	FilesRemoved       int
 	FilesMissing       int
+	FilesSkipped       int
 	DirectoriesRemoved int
 	Errors             []error
 	Files              []string
+	SkippedFiles       []string
 }
 
 // Rewind removes files previously created by ign and then deletes .ign.
@@ -53,7 +56,7 @@ func Rewind(ctx context.Context, opts RewindOptions) (*RewindResult, error) {
 		)
 	}
 
-	files, err := loadManagedFilesForRewind(ctx, opts)
+	files, skippedFiles, err := loadManagedFilesForRewind(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -68,8 +71,10 @@ func Rewind(ctx context.Context, opts RewindOptions) (*RewindResult, error) {
 	})
 
 	result := &RewindResult{
-		Errors: []error{},
-		Files:  append([]string(nil), files...),
+		Errors:       []error{},
+		Files:        append([]string(nil), files...),
+		FilesSkipped: len(skippedFiles),
+		SkippedFiles: append([]string(nil), skippedFiles...),
 	}
 
 	removedDirs := make(map[string]struct{})
@@ -128,43 +133,43 @@ func Rewind(ctx context.Context, opts RewindOptions) (*RewindResult, error) {
 	return result, nil
 }
 
-func loadManagedFilesForRewind(ctx context.Context, opts RewindOptions) ([]string, error) {
+func loadManagedFilesForRewind(ctx context.Context, opts RewindOptions) ([]string, []string, error) {
 	manifest, err := config.LoadIgnManifest(manifestPath())
 	if err == nil {
-		return dedupePaths(manifest.Files), nil
+		return dedupePaths(manifest.Files), nil, nil
 	}
 
 	if cfgErr, ok := err.(*config.ConfigError); !ok || cfgErr.Type != config.ConfigNotFound {
-		return nil, NewCheckoutError("failed to load ign-files.json", err)
+		return nil, nil, NewCheckoutError("failed to load ign-files.json", err)
 	}
 
 	debug.Debug("[app] ign-files.json not found; falling back to current template dry-run")
 	return buildManagedFilesFromCurrentTemplate(ctx, opts)
 }
 
-func buildManagedFilesFromCurrentTemplate(ctx context.Context, opts RewindOptions) ([]string, error) {
+func buildManagedFilesFromCurrentTemplate(ctx context.Context, opts RewindOptions) ([]string, []string, error) {
 	ignConfigPath := filepath.Join(model.IgnConfigDir, model.IgnProjectConfigFile)
 	ignVarPath := filepath.Join(model.IgnConfigDir, model.IgnVarFile)
 
 	ignConfig, err := config.LoadIgnConfig(ignConfigPath)
 	if err != nil {
-		return nil, NewCheckoutError("failed to load .ign/ign.json: run 'ign checkout <template-url>' first", err)
+		return nil, nil, NewCheckoutError("failed to load .ign/ign.json: run 'ign checkout <template-url>' first", err)
 	}
 
 	ignVar, err := config.LoadIgnVarJson(ignVarPath)
 	if err != nil {
-		return nil, NewCheckoutError("failed to load .ign/ign-var.json: run 'ign checkout <template-url>' first", err)
+		return nil, nil, NewCheckoutError("failed to load .ign/ign-var.json: run 'ign checkout <template-url>' first", err)
 	}
 
 	normalizedURL := NormalizeTemplateURL(ignConfig.Template.URL)
 	prov, err := provider.NewProviderWithToken(normalizedURL, opts.GitHubToken)
 	if err != nil {
-		return nil, NewCheckoutError("failed to create provider", err)
+		return nil, nil, NewCheckoutError("failed to create provider", err)
 	}
 
 	templateRef, err := prov.Resolve(normalizedURL)
 	if err != nil {
-		return nil, NewCheckoutError("failed to resolve template URL", err)
+		return nil, nil, NewCheckoutError("failed to resolve template URL", err)
 	}
 	if ignConfig.Template.Ref != "" {
 		templateRef.Ref = ignConfig.Template.Ref
@@ -175,12 +180,12 @@ func buildManagedFilesFromCurrentTemplate(ctx context.Context, opts RewindOption
 
 	template, err := prov.Fetch(ctx, templateRef)
 	if err != nil {
-		return nil, NewTemplateFetchError("failed to fetch template", err)
+		return nil, nil, NewTemplateFetchError("failed to fetch template", err)
 	}
 
 	_, vars, err := prepareVariablesForGeneration(template.Config.Variables, ignVar.Variables, model.IgnConfigDir, opts.OutputDir)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	gen := generator.NewGenerator()
@@ -191,10 +196,39 @@ func buildManagedFilesFromCurrentTemplate(ctx context.Context, opts RewindOption
 		Overwrite: true,
 	})
 	if err != nil {
-		return nil, NewCheckoutError("failed to enumerate generated files", err)
+		return nil, nil, NewCheckoutError("failed to enumerate generated files", err)
 	}
 
-	return dedupePaths(genResult.Files), nil
+	return managedFilesMatchingDryRunContent(genResult.DryRunFiles, opts.OutputDir)
+}
+
+func managedFilesMatchingDryRunContent(files []generator.DryRunFile, outputDir string) ([]string, []string, error) {
+	managed := make([]string, 0, len(files))
+	skipped := make([]string, 0)
+	for _, file := range files {
+		if file.Path == "" || !file.Exists {
+			continue
+		}
+
+		cleanPath, err := validateManagedPath(file.Path, outputDir)
+		if err != nil {
+			debug.Debug("[app] Skipping rewind fallback candidate %s: %v", file.Path, err)
+			continue
+		}
+
+		current, err := os.ReadFile(cleanPath)
+		if err != nil {
+			debug.Debug("[app] Skipping rewind fallback candidate %s: %v", cleanPath, err)
+			continue
+		}
+		if !bytes.Equal(current, file.Content) {
+			debug.Debug("[app] Skipping rewind fallback candidate %s: content differs from generated template output", cleanPath)
+			skipped = append(skipped, cleanPath)
+			continue
+		}
+		managed = append(managed, cleanPath)
+	}
+	return dedupePaths(managed), dedupePaths(skipped), nil
 }
 
 func dedupePaths(paths []string) []string {

--- a/internal/app/rewind_test.go
+++ b/internal/app/rewind_test.go
@@ -100,3 +100,57 @@ func TestRewind_RejectsManagedPathsOutsideOutputDir(t *testing.T) {
 		t.Fatalf(".ign should be preserved after rewind failure: %v", statErr)
 	}
 }
+
+func TestRewind_MissingManifestSkipsDifferentPreexistingFile(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	templateDir := filepath.Join(tempDir, "template")
+	if err := os.MkdirAll(templateDir, 0755); err != nil {
+		t.Fatalf("failed to create template directory: %v", err)
+	}
+	templateConfig := `{"name":"rewind-template","version":"1.0.0","hash":"` + testHash1 + `","variables":{}}`
+	if err := os.WriteFile(filepath.Join(templateDir, model.IgnTemplateConfigFile), []byte(templateConfig), 0644); err != nil {
+		t.Fatalf("failed to write template config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(templateDir, "README.md"), []byte("template content\n"), 0644); err != nil {
+		t.Fatalf("failed to write template README: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, "README.md"), []byte("user content\n"), 0644); err != nil {
+		t.Fatalf("failed to write user README: %v", err)
+	}
+
+	if err := os.MkdirAll(model.IgnConfigDir, 0755); err != nil {
+		t.Fatalf("failed to create .ign directory: %v", err)
+	}
+	if err := config.SaveIgnConfig(
+		filepath.Join(model.IgnConfigDir, model.IgnProjectConfigFile),
+		&model.IgnConfig{Template: model.TemplateSource{URL: templateDir, Ref: "main"}, Hash: testHash1},
+	); err != nil {
+		t.Fatalf("failed to save ign config: %v", err)
+	}
+	if err := config.SaveIgnVarJson(
+		filepath.Join(model.IgnConfigDir, model.IgnVarFile),
+		&model.IgnVarJson{Variables: map[string]interface{}{}},
+	); err != nil {
+		t.Fatalf("failed to save ign vars: %v", err)
+	}
+
+	result, err := Rewind(context.Background(), RewindOptions{OutputDir: tempDir})
+	if err != nil {
+		t.Fatalf("Rewind failed: %v", err)
+	}
+	if result.FilesRemoved != 0 {
+		t.Fatalf("FilesRemoved = %d, want 0", result.FilesRemoved)
+	}
+	if result.FilesSkipped != 1 {
+		t.Fatalf("FilesSkipped = %d, want 1", result.FilesSkipped)
+	}
+	content, err := os.ReadFile(filepath.Join(tempDir, "README.md"))
+	if err != nil {
+		t.Fatalf("failed to read README after rewind: %v", err)
+	}
+	if string(content) != "user content\n" {
+		t.Fatalf("README content = %q, want user content", content)
+	}
+}

--- a/internal/app/template_fetch.go
+++ b/internal/app/template_fetch.go
@@ -1,0 +1,56 @@
+package app
+
+import (
+	"context"
+
+	"github.com/tacogips/ign/internal/debug"
+	"github.com/tacogips/ign/internal/template/model"
+	"github.com/tacogips/ign/internal/template/provider"
+)
+
+type trackedTemplateFetchOptions struct {
+	Source      model.TemplateSource
+	GitHubToken string
+}
+
+type trackedTemplateFetchResult struct {
+	Template      *model.Template
+	TemplateRef   model.TemplateRef
+	NormalizedURL string
+}
+
+func fetchTrackedTemplate(ctx context.Context, opts trackedTemplateFetchOptions) (*trackedTemplateFetchResult, error) {
+	normalizedURL := NormalizeTemplateURL(opts.Source.URL)
+	debug.DebugValue("[app] Normalized template URL", normalizedURL)
+
+	prov, err := provider.NewProviderWithToken(normalizedURL, opts.GitHubToken)
+	if err != nil {
+		debug.Debug("[app] Failed to create provider: %v", err)
+		return nil, NewCheckoutError("failed to create provider", err)
+	}
+
+	templateRef, err := prov.Resolve(normalizedURL)
+	if err != nil {
+		debug.Debug("[app] Failed to resolve template URL: %v", err)
+		return nil, NewCheckoutError("failed to resolve template URL", err)
+	}
+
+	if opts.Source.Ref != "" {
+		templateRef.Ref = opts.Source.Ref
+	}
+	if opts.Source.Path != "" {
+		templateRef.Path = opts.Source.Path
+	}
+
+	template, err := prov.Fetch(ctx, templateRef)
+	if err != nil {
+		debug.Debug("[app] Failed to fetch template: %v", err)
+		return nil, NewTemplateFetchError("failed to fetch template", err)
+	}
+
+	return &trackedTemplateFetchResult{
+		Template:      template,
+		TemplateRef:   templateRef,
+		NormalizedURL: normalizedURL,
+	}, nil
+}

--- a/internal/app/template_update.go
+++ b/internal/app/template_update.go
@@ -538,7 +538,7 @@ func updateIgnJson(path string, result *UpdateTemplateResult, existing *model.Ig
 		return NewValidationError("failed to marshal ign-template.json", err)
 	}
 
-	if err := os.WriteFile(path, data, 0644); err != nil {
+	if err := config.WriteFileAtomic(path, data, 0644); err != nil {
 		return NewValidationError("failed to write ign-template.json", err)
 	}
 

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -183,14 +183,8 @@ func PrepareUpdate(ctx context.Context, opts UpdateOptions) (*PrepareUpdateResul
 	newHash := template.Config.Hash
 	debug.DebugValue("[app] Template hash from ign-template.json", newHash)
 
-	// Validate hash is present
-	if newHash == "" {
-		debug.Debug("[app] Template hash is missing in ign-template.json")
-		return nil, NewValidationError(
-			"template is missing hash in ign-template.json.\n"+
-				"The template author needs to run 'ign template update' to generate the hash.",
-			nil,
-		)
+	if err := validateTemplateHash(newHash); err != nil {
+		return nil, err
 	}
 
 	hashChanged := newHash != ignConfig.Hash
@@ -315,38 +309,6 @@ func CompleteUpdate(ctx context.Context, opts CompleteUpdateOptions) (*UpdateRes
 		return nil, err
 	}
 
-	// Update configuration files (unless dry-run)
-	if !opts.DryRun {
-		// Update ign.json with new hash
-		debug.Debug("[app] Updating ign.json with new hash")
-		prep.IgnConfig.Hash = prep.NewHash
-		prep.IgnConfig.Metadata = &model.FileMetadata{
-			GeneratedAt:     time.Now(),
-			GeneratedBy:     "ign update",
-			TemplateName:    prep.IgnJson.Name,
-			TemplateVersion: prep.IgnJson.Version,
-			IgnVersion:      build.Version(),
-		}
-
-		if err := config.SaveIgnConfig(prep.IgnConfigPath, prep.IgnConfig); err != nil {
-			debug.Debug("[app] Failed to save ign.json: %v", err)
-			return nil, NewCheckoutError("failed to save ign.json", err)
-		}
-		debug.Debug("[app] ign.json updated successfully")
-
-		// Update ign-var.json with merged variables (no metadata as it's already in ign.json)
-		debug.Debug("[app] Updating ign-var.json with merged variables")
-		ignVarJson := &model.IgnVarJson{
-			Variables: rawVars,
-		}
-
-		if err := config.SaveIgnVarJson(prep.IgnVarPath, ignVarJson); err != nil {
-			debug.Debug("[app] Failed to save ign-var.json: %v", err)
-			return nil, NewCheckoutError("failed to save ign-var.json", err)
-		}
-		debug.Debug("[app] ign-var.json updated successfully")
-	}
-
 	// Create generator
 	gen := generator.NewGenerator()
 
@@ -363,6 +325,14 @@ func CompleteUpdate(ctx context.Context, opts CompleteUpdateOptions) (*UpdateRes
 
 	// Generate or dry run
 	var genResult *generator.GenerateResult
+	var rollback *checkoutGenerationRollback
+	if !opts.DryRun {
+		rollback, err = prepareCheckoutGenerationRollback(ctx, gen, genOpts)
+		if err != nil {
+			return nil, err
+		}
+		defer rollback.cleanup()
+	}
 	if opts.DryRun {
 		debug.Debug("[app] Starting dry run generation")
 		genResult, err = gen.DryRun(ctx, genOpts)
@@ -373,12 +343,15 @@ func CompleteUpdate(ctx context.Context, opts CompleteUpdateOptions) (*UpdateRes
 
 	if err != nil {
 		debug.Debug("[app] Generation failed: %v", err)
+		if rollback != nil {
+			rollback.rollback(genResult)
+		}
 		return nil, NewCheckoutError("generation failed", err)
 	}
 	debug.Debug("[app] Generation completed successfully")
 
 	manifestPath := manifestPathFromConfigPath(prep.IgnConfigPath)
-	removedManagedFiles, err := cleanupRemovedManagedFilesForUpdate(ctx, cleanupRemovedManagedFilesOptions{
+	removedManagedFiles, cleanupErr := cleanupRemovedManagedFilesForUpdate(ctx, cleanupRemovedManagedFilesOptions{
 		ManifestPath:   manifestPath,
 		OutputDir:      opts.OutputDir,
 		Template:       prep.Template,
@@ -387,15 +360,13 @@ func CompleteUpdate(ctx context.Context, opts CompleteUpdateOptions) (*UpdateRes
 		Overwrite:      opts.Overwrite,
 		DryRun:         opts.DryRun,
 	})
-	if err != nil {
-		debug.Debug("[app] Failed to remove stale managed files: %v", err)
-		return nil, NewCheckoutError("failed to remove files no longer present in template", err)
+	if cleanupErr != nil {
+		debug.Debug("[app] Failed to remove stale managed files: %v", cleanupErr)
 	}
 
 	if !opts.DryRun {
-		if err := saveManifestFromGenerateResultExcluding(manifestPath, genResult, removedManagedFiles.RemovedCanonicalPaths); err != nil {
-			debug.Debug("[app] Failed to save ign-files.json: %v", err)
-			return nil, NewCheckoutError("failed to save ign-files.json", err)
+		if err := saveCompleteUpdateArtifacts(prep, rawVars, genResult, removedManagedFiles, rollback); err != nil {
+			return nil, err
 		}
 	}
 
@@ -429,7 +400,73 @@ func CompleteUpdate(ctx context.Context, opts CompleteUpdateOptions) (*UpdateRes
 	}
 
 	debug.Debug("[app] CompleteUpdate workflow completed successfully")
+	if cleanupErr != nil {
+		return result, NewCheckoutError("failed to remove files no longer present in template", cleanupErr)
+	}
 	return result, nil
+}
+
+func saveCompleteUpdateArtifacts(prep *PrepareUpdateResult, rawVars map[string]interface{}, genResult *generator.GenerateResult, removedManagedFiles *cleanupRemovedManagedFilesResult, rollback *checkoutGenerationRollback) error {
+	if removedManagedFiles == nil {
+		removedManagedFiles = &cleanupRemovedManagedFilesResult{}
+	}
+
+	ignConfigSnapshot, err := rollback.snapshotPath(prep.IgnConfigPath)
+	if err != nil {
+		rollback.rollback(genResult)
+		return NewCheckoutError("failed to prepare ign.json rollback", err)
+	}
+	ignVarSnapshot, err := rollback.snapshotPath(prep.IgnVarPath)
+	if err != nil {
+		rollback.rollback(genResult)
+		return NewCheckoutError("failed to prepare ign-var.json rollback", err)
+	}
+	manifestPath := manifestPathFromConfigPath(prep.IgnConfigPath)
+	manifestSnapshot, err := rollback.snapshotPath(manifestPath)
+	if err != nil {
+		rollback.rollback(genResult)
+		return NewCheckoutError("failed to prepare ign-files.json rollback", err)
+	}
+
+	if err := saveManifestFromGenerateResultExcluding(manifestPath, genResult, removedManagedFiles.RemovedCanonicalPaths); err != nil {
+		debug.Debug("[app] Failed to save ign-files.json: %v", err)
+		rollback.rollback(genResult)
+		restoreUpdateArtifactSnapshots(ignConfigSnapshot, ignVarSnapshot, manifestSnapshot)
+		return NewCheckoutError("failed to save ign-files.json", err)
+	}
+
+	prep.IgnConfig.Hash = prep.NewHash
+	prep.IgnConfig.Metadata = &model.FileMetadata{
+		GeneratedAt:     time.Now(),
+		GeneratedBy:     "ign update",
+		TemplateName:    prep.IgnJson.Name,
+		TemplateVersion: prep.IgnJson.Version,
+		IgnVersion:      build.Version(),
+	}
+	if err := config.SaveIgnConfig(prep.IgnConfigPath, prep.IgnConfig); err != nil {
+		debug.Debug("[app] Failed to save ign.json: %v", err)
+		rollback.rollback(genResult)
+		restoreUpdateArtifactSnapshots(ignConfigSnapshot, ignVarSnapshot, manifestSnapshot)
+		return NewCheckoutError("failed to save ign.json", err)
+	}
+
+	ignVarJson := &model.IgnVarJson{Variables: rawVars}
+	if err := config.SaveIgnVarJson(prep.IgnVarPath, ignVarJson); err != nil {
+		debug.Debug("[app] Failed to save ign-var.json: %v", err)
+		rollback.rollback(genResult)
+		restoreUpdateArtifactSnapshots(ignConfigSnapshot, ignVarSnapshot, manifestSnapshot)
+		return NewCheckoutError("failed to save ign-var.json", err)
+	}
+
+	return nil
+}
+
+func restoreUpdateArtifactSnapshots(entries ...checkoutRollbackEntry) {
+	for i := len(entries) - 1; i >= 0; i-- {
+		if err := restoreCheckoutRollbackEntry(entries[i]); err != nil {
+			debug.Debug("[app] Failed to restore update artifact %s: %v", entries[i].path, err)
+		}
+	}
 }
 
 // GetNewVariableDefinitions returns VarDef for new variables that need prompting.

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -13,7 +13,6 @@ import (
 	"github.com/tacogips/ign/internal/debug"
 	"github.com/tacogips/ign/internal/template/generator"
 	"github.com/tacogips/ign/internal/template/model"
-	"github.com/tacogips/ign/internal/template/provider"
 )
 
 // UpdateOptions contains options for the update command.
@@ -30,6 +29,8 @@ type UpdateOptions struct {
 	Verbose bool
 	// GitHubToken is the GitHub personal access token (optional).
 	GitHubToken string
+	// TargetRef overrides the stored template ref for this update.
+	TargetRef string
 }
 
 // PrepareUpdateResult contains the result of update preparation.
@@ -56,6 +57,16 @@ type PrepareUpdateResult struct {
 	IgnVarPath string
 	// IgnConfig is the existing ign.json configuration.
 	IgnConfig *model.IgnConfig
+	// PreviousRef is the ref stored before applying an update ref override.
+	PreviousRef string
+	// RequestedRef is the requested ref override.
+	RequestedRef string
+	// EffectiveRef is the ref used to fetch the template.
+	EffectiveRef string
+	// RefOverrideRequested indicates whether update was called with a ref override.
+	RefOverrideRequested bool
+	// RefChanged indicates whether the requested ref differs from the stored ref.
+	RefChanged bool
 }
 
 // UpdateResult contains the results of the update operation.
@@ -86,6 +97,10 @@ type UpdateResult struct {
 	DryRunFiles []DryRunFile
 	// Directories contains directories that would be created (dry-run only).
 	Directories []string
+	// RefChanged indicates whether the stored template ref changed.
+	RefChanged bool
+	// RefOverrideRequested indicates whether update was called with a ref override.
+	RefOverrideRequested bool
 }
 
 // PrepareUpdate prepares for update by checking if .ign exists and fetching template.
@@ -101,6 +116,7 @@ func PrepareUpdate(ctx context.Context, opts UpdateOptions) (*PrepareUpdateResul
 	debug.DebugValue("[app] Overwrite", opts.Overwrite)
 	debug.DebugValue("[app] DryRun", opts.DryRun)
 	debug.DebugValue("[app] Verbose", opts.Verbose)
+	debug.DebugValue("[app] TargetRef", opts.TargetRef)
 
 	// Step 1: Check if .ign directory exists
 	if _, err := os.Stat(configDir); os.IsNotExist(err) {
@@ -125,6 +141,15 @@ func PrepareUpdate(ctx context.Context, opts UpdateOptions) (*PrepareUpdateResul
 	debug.DebugValue("[app] Template URL", ignConfig.Template.URL)
 	debug.DebugValue("[app] Current hash", ignConfig.Hash)
 
+	previousRef := ignConfig.Template.Ref
+	requestedRef := opts.TargetRef
+	refOverrideRequested := requestedRef != ""
+	if refOverrideRequested {
+		if err := ValidateGitRef(requestedRef); err != nil {
+			return nil, NewValidationError("invalid update ref", err)
+		}
+	}
+
 	// Step 3: Load existing variables
 	debug.Debug("[app] Loading existing ign-var.json")
 	ignVar, err := config.LoadIgnVarJson(ignVarPath)
@@ -143,37 +168,20 @@ func PrepareUpdate(ctx context.Context, opts UpdateOptions) (*PrepareUpdateResul
 
 	// Step 4: Create provider and fetch template
 	templateSource := ignConfig.Template
-	normalizedURL := NormalizeTemplateURL(templateSource.URL)
-	debug.DebugValue("[app] Normalized template URL", normalizedURL)
-
-	debug.Debug("[app] Creating template provider")
-	prov, err := provider.NewProviderWithToken(normalizedURL, opts.GitHubToken)
-	if err != nil {
-		debug.Debug("[app] Failed to create provider: %v", err)
-		return nil, NewCheckoutError("failed to create provider", err)
-	}
-
-	debug.Debug("[app] Resolving template URL")
-	templateRef, err := prov.Resolve(normalizedURL)
-	if err != nil {
-		debug.Debug("[app] Failed to resolve template URL: %v", err)
-		return nil, NewCheckoutError("failed to resolve template URL", err)
-	}
-
-	// Use ref and path from configuration
-	if templateSource.Ref != "" {
-		templateRef.Ref = templateSource.Ref
-	}
-	if templateSource.Path != "" {
-		templateRef.Path = templateSource.Path
+	if refOverrideRequested {
+		templateSource.Ref = requestedRef
 	}
 
 	debug.Debug("[app] Fetching template from provider")
-	template, err := prov.Fetch(ctx, templateRef)
+	fetched, err := fetchTrackedTemplate(ctx, trackedTemplateFetchOptions{
+		Source:      templateSource,
+		GitHubToken: opts.GitHubToken,
+	})
 	if err != nil {
-		debug.Debug("[app] Failed to fetch template: %v", err)
-		return nil, NewTemplateFetchError("failed to fetch template", err)
+		return nil, err
 	}
+	template := fetched.Template
+	effectiveRef := fetched.TemplateRef.Ref
 	debug.Debug("[app] Template fetched successfully")
 	debug.DebugValue("[app] Template name", template.Config.Name)
 	debug.DebugValue("[app] Template version", template.Config.Version)
@@ -188,7 +196,9 @@ func PrepareUpdate(ctx context.Context, opts UpdateOptions) (*PrepareUpdateResul
 	}
 
 	hashChanged := newHash != ignConfig.Hash
+	refChanged := refOverrideRequested && requestedRef != previousRef
 	debug.DebugValue("[app] Hash changed", hashChanged)
+	debug.DebugValue("[app] Ref changed", refChanged)
 
 	// Step 6: Find new and removed variables
 	newVars, removedVars := findVariableChanges(existingVars, template.Config.Variables)
@@ -196,17 +206,22 @@ func PrepareUpdate(ctx context.Context, opts UpdateOptions) (*PrepareUpdateResul
 	debug.DebugValue("[app] Removed variables", removedVars)
 
 	result := &PrepareUpdateResult{
-		Template:      template,
-		IgnJson:       &template.Config,
-		ExistingVars:  existingVars,
-		NewVars:       newVars,
-		RemovedVars:   removedVars,
-		CurrentHash:   ignConfig.Hash,
-		NewHash:       newHash,
-		HashChanged:   hashChanged,
-		IgnConfigPath: ignConfigPath,
-		IgnVarPath:    ignVarPath,
-		IgnConfig:     ignConfig,
+		Template:             template,
+		IgnJson:              &template.Config,
+		ExistingVars:         existingVars,
+		NewVars:              newVars,
+		RemovedVars:          removedVars,
+		CurrentHash:          ignConfig.Hash,
+		NewHash:              newHash,
+		HashChanged:          hashChanged,
+		IgnConfigPath:        ignConfigPath,
+		IgnVarPath:           ignVarPath,
+		IgnConfig:            ignConfig,
+		PreviousRef:          previousRef,
+		RequestedRef:         requestedRef,
+		EffectiveRef:         effectiveRef,
+		RefOverrideRequested: refOverrideRequested,
+		RefChanged:           refChanged,
 	}
 
 	debug.Debug("[app] PrepareUpdate completed successfully")
@@ -309,6 +324,21 @@ func CompleteUpdate(ctx context.Context, opts CompleteUpdateOptions) (*UpdateRes
 		return nil, err
 	}
 
+	if shouldCompleteUpdateConfigOnly(prep, opts) {
+		if !opts.DryRun {
+			if err := saveCompleteUpdateConfigOnlyArtifacts(prep, rawVars); err != nil {
+				return nil, err
+			}
+		}
+		return &UpdateResult{
+			HashChanged:          prep.HashChanged,
+			NewVariables:         prep.NewVars,
+			RemovedVariables:     prep.RemovedVars,
+			RefChanged:           prep.RefChanged,
+			RefOverrideRequested: prep.RefOverrideRequested,
+		}, nil
+	}
+
 	// Create generator
 	gen := generator.NewGenerator()
 
@@ -372,17 +402,19 @@ func CompleteUpdate(ctx context.Context, opts CompleteUpdateOptions) (*UpdateRes
 
 	// Build result
 	result := &UpdateResult{
-		HashChanged:      prep.HashChanged,
-		NewVariables:     prep.NewVars,
-		RemovedVariables: prep.RemovedVars,
-		FilesCreated:     genResult.FilesCreated,
-		FilesSkipped:     genResult.FilesSkipped,
-		FilesOverwritten: genResult.FilesOverwritten,
-		FilesDeleted:     removedManagedFiles.FilesDeleted,
-		Errors:           genResult.Errors,
-		Files:            genResult.Files,
-		DeletedFiles:     removedManagedFiles.DeletedFiles,
-		Directories:      genResult.Directories,
+		HashChanged:          prep.HashChanged,
+		NewVariables:         prep.NewVars,
+		RemovedVariables:     prep.RemovedVars,
+		FilesCreated:         genResult.FilesCreated,
+		FilesSkipped:         genResult.FilesSkipped,
+		FilesOverwritten:     genResult.FilesOverwritten,
+		FilesDeleted:         removedManagedFiles.FilesDeleted,
+		Errors:               genResult.Errors,
+		Files:                genResult.Files,
+		DeletedFiles:         removedManagedFiles.DeletedFiles,
+		Directories:          genResult.Directories,
+		RefChanged:           prep.RefChanged,
+		RefOverrideRequested: prep.RefOverrideRequested,
 	}
 
 	// Convert dry-run files
@@ -404,6 +436,10 @@ func CompleteUpdate(ctx context.Context, opts CompleteUpdateOptions) (*UpdateRes
 		return result, NewCheckoutError("failed to remove files no longer present in template", cleanupErr)
 	}
 	return result, nil
+}
+
+func shouldCompleteUpdateConfigOnly(prep *PrepareUpdateResult, opts CompleteUpdateOptions) bool {
+	return prep.RefChanged && !prep.HashChanged && !opts.Overwrite
 }
 
 func saveCompleteUpdateArtifacts(prep *PrepareUpdateResult, rawVars map[string]interface{}, genResult *generator.GenerateResult, removedManagedFiles *cleanupRemovedManagedFilesResult, rollback *checkoutGenerationRollback) error {
@@ -435,14 +471,7 @@ func saveCompleteUpdateArtifacts(prep *PrepareUpdateResult, rawVars map[string]i
 		return NewCheckoutError("failed to save ign-files.json", err)
 	}
 
-	prep.IgnConfig.Hash = prep.NewHash
-	prep.IgnConfig.Metadata = &model.FileMetadata{
-		GeneratedAt:     time.Now(),
-		GeneratedBy:     "ign update",
-		TemplateName:    prep.IgnJson.Name,
-		TemplateVersion: prep.IgnJson.Version,
-		IgnVersion:      build.Version(),
-	}
+	applyCompleteUpdateConfig(prep)
 	if err := config.SaveIgnConfig(prep.IgnConfigPath, prep.IgnConfig); err != nil {
 		debug.Debug("[app] Failed to save ign.json: %v", err)
 		rollback.rollback(genResult)
@@ -459,6 +488,48 @@ func saveCompleteUpdateArtifacts(prep *PrepareUpdateResult, rawVars map[string]i
 	}
 
 	return nil
+}
+
+func saveCompleteUpdateConfigOnlyArtifacts(prep *PrepareUpdateResult, rawVars map[string]interface{}) error {
+	rollback := &checkoutGenerationRollback{}
+	defer rollback.cleanup()
+
+	ignConfigSnapshot, err := rollback.snapshotPath(prep.IgnConfigPath)
+	if err != nil {
+		return NewCheckoutError("failed to prepare ign.json rollback", err)
+	}
+	ignVarSnapshot, err := rollback.snapshotPath(prep.IgnVarPath)
+	if err != nil {
+		return NewCheckoutError("failed to prepare ign-var.json rollback", err)
+	}
+
+	applyCompleteUpdateConfig(prep)
+	if err := config.SaveIgnConfig(prep.IgnConfigPath, prep.IgnConfig); err != nil {
+		restoreUpdateArtifactSnapshots(ignConfigSnapshot, ignVarSnapshot)
+		return NewCheckoutError("failed to save ign.json", err)
+	}
+
+	ignVarJson := &model.IgnVarJson{Variables: rawVars}
+	if err := config.SaveIgnVarJson(prep.IgnVarPath, ignVarJson); err != nil {
+		restoreUpdateArtifactSnapshots(ignConfigSnapshot, ignVarSnapshot)
+		return NewCheckoutError("failed to save ign-var.json", err)
+	}
+
+	return nil
+}
+
+func applyCompleteUpdateConfig(prep *PrepareUpdateResult) {
+	prep.IgnConfig.Hash = prep.NewHash
+	if prep.RefOverrideRequested {
+		prep.IgnConfig.Template.Ref = prep.RequestedRef
+	}
+	prep.IgnConfig.Metadata = &model.FileMetadata{
+		GeneratedAt:     time.Now(),
+		GeneratedBy:     "ign update",
+		TemplateName:    prep.IgnJson.Name,
+		TemplateVersion: prep.IgnJson.Version,
+		IgnVersion:      build.Version(),
+	}
 }
 
 func restoreUpdateArtifactSnapshots(entries ...checkoutRollbackEntry) {

--- a/internal/app/update_test.go
+++ b/internal/app/update_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/tacogips/ign/internal/config"
@@ -47,6 +48,109 @@ func setupTestTemplate(t *testing.T, dir string, hash string) {
 	ignVarPath := filepath.Join(ignDir, "ign-var.json")
 	if err := config.SaveIgnVarJson(ignVarPath, ignVar); err != nil {
 		t.Fatalf("Failed to save ign-var.json: %v", err)
+	}
+}
+
+func TestPrepareUpdateRejectsInvalidTemplateHash(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	templateDir := filepath.Join(tempDir, "template")
+	if err := os.MkdirAll(templateDir, 0755); err != nil {
+		t.Fatalf("failed to create template directory: %v", err)
+	}
+	templateConfig := `{"name":"bad-hash-template","version":"1.0.0","hash":"not-a-sha","variables":{}}`
+	if err := os.WriteFile(filepath.Join(templateDir, model.IgnTemplateConfigFile), []byte(templateConfig), 0644); err != nil {
+		t.Fatalf("failed to write template config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(templateDir, "README.md"), []byte("content"), 0644); err != nil {
+		t.Fatalf("failed to write template file: %v", err)
+	}
+
+	if err := os.MkdirAll(model.IgnConfigDir, 0755); err != nil {
+		t.Fatalf("failed to create .ign: %v", err)
+	}
+	ignConfig := &model.IgnConfig{
+		Template: model.TemplateSource{URL: templateDir, Ref: "main"},
+		Hash:     testHash1,
+	}
+	if err := config.SaveIgnConfig(filepath.Join(model.IgnConfigDir, model.IgnProjectConfigFile), ignConfig); err != nil {
+		t.Fatalf("failed to save ign config: %v", err)
+	}
+	if err := config.SaveIgnVarJson(filepath.Join(model.IgnConfigDir, model.IgnVarFile), &model.IgnVarJson{Variables: map[string]interface{}{}}); err != nil {
+		t.Fatalf("failed to save ign vars: %v", err)
+	}
+
+	_, err := PrepareUpdate(context.Background(), UpdateOptions{OutputDir: tempDir})
+	if err == nil {
+		t.Fatal("PrepareUpdate expected invalid hash error")
+	}
+	if !strings.Contains(err.Error(), "valid SHA256") {
+		t.Fatalf("PrepareUpdate error = %v, want valid SHA256 message", err)
+	}
+}
+
+func TestCompleteUpdatePersistsManifestWhenCleanupPartiallyFails(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	setupTestTemplate(t, tempDir, testHash1)
+	blockingDir := filepath.Join(tempDir, "stale.txt")
+	if err := os.MkdirAll(blockingDir, 0755); err != nil {
+		t.Fatalf("failed to create blocking directory: %v", err)
+	}
+	manifestPath := filepath.Join(tempDir, ".ign", model.IgnManifestFile)
+	if err := config.SaveIgnManifest(manifestPath, &model.IgnManifest{Files: []string{blockingDir}}); err != nil {
+		t.Fatalf("failed to save manifest: %v", err)
+	}
+
+	template := &model.Template{
+		RootPath: tempDir,
+		Config: model.IgnJson{
+			Name:      "test-template",
+			Version:   "2.0.0",
+			Hash:      testHash2,
+			Variables: map[string]model.VarDef{},
+		},
+		Files: []model.TemplateFile{{Path: "new.txt", Content: []byte("new content")}},
+	}
+	prep := &PrepareUpdateResult{
+		Template:      template,
+		IgnJson:       &template.Config,
+		ExistingVars:  map[string]interface{}{},
+		CurrentHash:   testHash1,
+		NewHash:       testHash2,
+		HashChanged:   true,
+		IgnConfigPath: filepath.Join(tempDir, ".ign", "ign.json"),
+		IgnVarPath:    filepath.Join(tempDir, ".ign", "ign-var.json"),
+		IgnConfig: &model.IgnConfig{
+			Template: model.TemplateSource{URL: "https://github.com/test/template"},
+			Hash:     testHash1,
+		},
+	}
+
+	result, err := CompleteUpdate(context.Background(), CompleteUpdateOptions{
+		PrepareResult: prep,
+		OutputDir:     tempDir,
+		Overwrite:     true,
+		OverwriteMode: generator.OverwriteAll,
+	})
+	if err == nil {
+		t.Fatal("CompleteUpdate expected cleanup error for stale directory")
+	}
+	if result == nil || result.FilesCreated != 1 {
+		t.Fatalf("CompleteUpdate result = %#v, want one created file", result)
+	}
+
+	manifest, err := config.LoadIgnManifest(manifestPath)
+	if err != nil {
+		t.Fatalf("failed to load manifest after partial cleanup: %v", err)
+	}
+	if !slices.Contains(manifest.Files, filepath.Join(tempDir, "new.txt")) {
+		t.Fatalf("manifest files = %v, want generated file recorded", manifest.Files)
+	}
+	if !slices.Contains(manifest.Files, blockingDir) {
+		t.Fatalf("manifest files = %v, want failed cleanup path retained", manifest.Files)
 	}
 }
 

--- a/internal/app/update_test.go
+++ b/internal/app/update_test.go
@@ -90,6 +90,159 @@ func TestPrepareUpdateRejectsInvalidTemplateHash(t *testing.T) {
 	}
 }
 
+func TestPrepareUpdate_TargetRefOverridesStoredRef(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	templatePath := writeVarsTemplate(t, tempDir, map[string]model.VarDef{})
+	writeProjectConfig(t, templatePath, "main", map[string]interface{}{})
+
+	result, err := PrepareUpdate(context.Background(), UpdateOptions{
+		OutputDir: tempDir,
+		TargetRef: "v2.0.0",
+	})
+	if err != nil {
+		t.Fatalf("PrepareUpdate returned error: %v", err)
+	}
+	if !result.RefOverrideRequested {
+		t.Fatal("RefOverrideRequested = false, want true")
+	}
+	if !result.RefChanged {
+		t.Fatal("RefChanged = false, want true")
+	}
+	if result.PreviousRef != "main" {
+		t.Fatalf("PreviousRef = %q, want main", result.PreviousRef)
+	}
+	if result.RequestedRef != "v2.0.0" {
+		t.Fatalf("RequestedRef = %q, want v2.0.0", result.RequestedRef)
+	}
+}
+
+func TestPrepareUpdate_InvalidTargetRefFailsBeforeFetch(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	writeProjectConfig(t, "./missing-template", "main", map[string]interface{}{})
+
+	_, err := PrepareUpdate(context.Background(), UpdateOptions{
+		OutputDir: tempDir,
+		TargetRef: "bad..ref",
+	})
+	if err == nil {
+		t.Fatal("PrepareUpdate expected invalid ref error")
+	}
+	if !strings.Contains(err.Error(), "invalid update ref") {
+		t.Fatalf("PrepareUpdate error = %v, want invalid update ref", err)
+	}
+}
+
+func TestCompleteUpdate_IdenticalHashRefRetargetPersistsConfigOnly(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	writeProjectConfig(t, "./template", "main", map[string]interface{}{"project_name": "demo"})
+	existingFile := filepath.Join(tempDir, "README.md")
+	if err := os.WriteFile(existingFile, []byte("existing"), 0644); err != nil {
+		t.Fatalf("failed to write existing file: %v", err)
+	}
+
+	template := &model.Template{
+		Config: model.IgnJson{
+			Name:      "test-template",
+			Version:   "1.0.0",
+			Hash:      testHash1,
+			Variables: map[string]model.VarDef{},
+		},
+		Files: []model.TemplateFile{{Path: "README.md", Content: []byte("new content")}},
+	}
+	prep := &PrepareUpdateResult{
+		Template:             template,
+		IgnJson:              &template.Config,
+		ExistingVars:         map[string]interface{}{"project_name": "demo"},
+		CurrentHash:          testHash1,
+		NewHash:              testHash1,
+		HashChanged:          false,
+		IgnConfigPath:        filepath.Join(tempDir, ".ign", "ign.json"),
+		IgnVarPath:           filepath.Join(tempDir, ".ign", "ign-var.json"),
+		IgnConfig:            &model.IgnConfig{Template: model.TemplateSource{URL: "./template", Ref: "main"}, Hash: testHash1},
+		PreviousRef:          "main",
+		RequestedRef:         "v2.0.0",
+		RefOverrideRequested: true,
+		RefChanged:           true,
+	}
+
+	result, err := CompleteUpdate(context.Background(), CompleteUpdateOptions{
+		PrepareResult: prep,
+		OutputDir:     tempDir,
+		Overwrite:     false,
+	})
+	if err != nil {
+		t.Fatalf("CompleteUpdate returned error: %v", err)
+	}
+	if !result.RefChanged {
+		t.Fatal("RefChanged = false, want true")
+	}
+
+	loaded, err := config.LoadIgnConfig(filepath.Join(tempDir, ".ign", "ign.json"))
+	if err != nil {
+		t.Fatalf("failed to load ign config: %v", err)
+	}
+	if loaded.Template.Ref != "v2.0.0" {
+		t.Fatalf("stored ref = %q, want v2.0.0", loaded.Template.Ref)
+	}
+	content, err := os.ReadFile(existingFile)
+	if err != nil {
+		t.Fatalf("failed to read existing file: %v", err)
+	}
+	if string(content) != "existing" {
+		t.Fatalf("existing file content = %q, want unchanged", content)
+	}
+}
+
+func TestCompleteUpdate_DryRunRefRetargetDoesNotPersist(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	writeProjectConfig(t, "./template", "main", map[string]interface{}{})
+	template := &model.Template{
+		Config: model.IgnJson{
+			Name:      "test-template",
+			Version:   "1.0.0",
+			Hash:      testHash1,
+			Variables: map[string]model.VarDef{},
+		},
+	}
+	prep := &PrepareUpdateResult{
+		Template:             template,
+		IgnJson:              &template.Config,
+		ExistingVars:         map[string]interface{}{},
+		CurrentHash:          testHash1,
+		NewHash:              testHash1,
+		IgnConfigPath:        filepath.Join(tempDir, ".ign", "ign.json"),
+		IgnVarPath:           filepath.Join(tempDir, ".ign", "ign-var.json"),
+		IgnConfig:            &model.IgnConfig{Template: model.TemplateSource{URL: "./template", Ref: "main"}, Hash: testHash1},
+		RequestedRef:         "v2.0.0",
+		RefOverrideRequested: true,
+		RefChanged:           true,
+	}
+
+	if _, err := CompleteUpdate(context.Background(), CompleteUpdateOptions{
+		PrepareResult: prep,
+		OutputDir:     tempDir,
+		DryRun:        true,
+	}); err != nil {
+		t.Fatalf("CompleteUpdate returned error: %v", err)
+	}
+
+	loaded, err := config.LoadIgnConfig(filepath.Join(tempDir, ".ign", "ign.json"))
+	if err != nil {
+		t.Fatalf("failed to load ign config: %v", err)
+	}
+	if loaded.Template.Ref != "main" {
+		t.Fatalf("stored ref = %q, want main", loaded.Template.Ref)
+	}
+}
+
 func TestCompleteUpdatePersistsManifestWhenCleanupPartiallyFails(t *testing.T) {
 	tempDir := t.TempDir()
 	t.Chdir(tempDir)

--- a/internal/app/vars.go
+++ b/internal/app/vars.go
@@ -1,0 +1,185 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/tacogips/ign/internal/config"
+	"github.com/tacogips/ign/internal/debug"
+	"github.com/tacogips/ign/internal/template/model"
+)
+
+// VarsOptions contains options for inspecting project template variables.
+type VarsOptions struct {
+	// GitHubToken is the GitHub personal access token (optional).
+	GitHubToken string
+}
+
+// VarsResult contains merged template declarations and current variable values.
+type VarsResult struct {
+	// DeclarationsAvailable indicates whether template declarations were fetched.
+	DeclarationsAvailable bool `json:"declarations_available"`
+	// Rows contains sorted variable inspection rows.
+	Rows []VarsRow `json:"rows"`
+	// UnsetCount is the number of rows without a current value.
+	UnsetCount int `json:"unset_count"`
+	// RequiredUnsetCount is the number of declared required rows without a current value.
+	RequiredUnsetCount int `json:"required_unset_count"`
+	// DeclarationError is a non-fatal error from fetching template declarations.
+	DeclarationError error `json:"-"`
+}
+
+// VarsRow contains one merged template variable declaration and current value.
+type VarsRow struct {
+	Name        string      `json:"name"`
+	Type        string      `json:"type,omitempty"`
+	Required    bool        `json:"required"`
+	Default     interface{} `json:"default,omitempty"`
+	Current     interface{} `json:"current,omitempty"`
+	HasCurrent  bool        `json:"has_current"`
+	Description string      `json:"description,omitempty"`
+	Unset       bool        `json:"unset"`
+	Declared    bool        `json:"declared"`
+}
+
+// InspectVars loads project variables and merges them with template declarations.
+func InspectVars(ctx context.Context, opts VarsOptions) (*VarsResult, error) {
+	configDir := model.IgnConfigDir
+	ignConfigPath := filepath.Join(configDir, model.IgnProjectConfigFile)
+	ignVarPath := filepath.Join(configDir, model.IgnVarFile)
+
+	if _, err := os.Stat(configDir); os.IsNotExist(err) {
+		return nil, NewValidationError(
+			"vars requires prior checkout: .ign directory not found.\n"+
+				"Run 'ign checkout <template-url>' first.",
+			nil,
+		)
+	}
+
+	ignConfig, err := config.LoadIgnConfig(ignConfigPath)
+	if err != nil {
+		return nil, NewCheckoutError(
+			"failed to load .ign/ign.json: run 'ign checkout <template-url>' first",
+			err,
+		)
+	}
+
+	ignVar, err := config.LoadIgnVarJson(ignVarPath)
+	if err != nil {
+		return nil, NewCheckoutError(
+			"failed to load .ign/ign-var.json: run 'ign checkout <template-url>' first",
+			err,
+		)
+	}
+	current := ignVar.Variables
+	if current == nil {
+		current = map[string]interface{}{}
+	}
+
+	fetched, fetchErr := fetchTrackedTemplate(ctx, trackedTemplateFetchOptions{
+		Source:      ignConfig.Template,
+		GitHubToken: opts.GitHubToken,
+	})
+	if fetchErr != nil {
+		debug.Debug("[app] Template declaration fetch failed for vars: %v", fetchErr)
+		return buildVarsResult(nil, current, fetchErr), nil
+	}
+
+	return buildVarsResult(fetched.Template.Config.Variables, current, nil), nil
+}
+
+func buildVarsResult(varDefs map[string]model.VarDef, current map[string]interface{}, declarationErr error) *VarsResult {
+	rowsByName := make(map[string]VarsRow)
+
+	for name, varDef := range varDefs {
+		value, hasCurrent := current[name]
+		unset := !hasCurrent
+		row := VarsRow{
+			Name:        name,
+			Type:        string(varDef.Type),
+			Required:    varDef.Required,
+			Default:     varDef.Default,
+			Current:     value,
+			HasCurrent:  hasCurrent,
+			Description: varDef.Description,
+			Unset:       unset,
+			Declared:    true,
+		}
+		rowsByName[name] = row
+	}
+
+	for name, value := range current {
+		if _, ok := rowsByName[name]; ok {
+			continue
+		}
+		rowsByName[name] = VarsRow{
+			Name:       name,
+			Current:    value,
+			HasCurrent: true,
+			Declared:   false,
+		}
+	}
+
+	names := make([]string, 0, len(rowsByName))
+	for name := range rowsByName {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	result := &VarsResult{
+		DeclarationsAvailable: declarationErr == nil,
+		DeclarationError:      declarationErr,
+		Rows:                  make([]VarsRow, 0, len(names)),
+	}
+	for _, name := range names {
+		row := rowsByName[name]
+		result.Rows = append(result.Rows, row)
+		if row.Unset {
+			result.UnsetCount++
+			if row.Declared && row.Required {
+				result.RequiredUnsetCount++
+			}
+		}
+	}
+
+	return result
+}
+
+// FilterUnsetVars returns a copy of result containing only unset rows.
+func FilterUnsetVars(result *VarsResult) *VarsResult {
+	if result == nil {
+		return nil
+	}
+
+	filtered := *result
+	filtered.Rows = make([]VarsRow, 0, len(result.Rows))
+	filtered.UnsetCount = 0
+	filtered.RequiredUnsetCount = 0
+
+	for _, row := range result.Rows {
+		if !row.Unset {
+			continue
+		}
+		filtered.Rows = append(filtered.Rows, row)
+		filtered.UnsetCount++
+		if row.Declared && row.Required {
+			filtered.RequiredUnsetCount++
+		}
+	}
+
+	return &filtered
+}
+
+func formatVarsValue(value interface{}, hasValue bool) string {
+	if !hasValue {
+		return ""
+	}
+	if value == nil {
+		return "null"
+	}
+	return strings.TrimSpace(fmt.Sprint(value))
+}

--- a/internal/app/vars_test.go
+++ b/internal/app/vars_test.go
@@ -1,0 +1,158 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tacogips/ign/internal/config"
+	"github.com/tacogips/ign/internal/template/model"
+)
+
+func TestInspectVars_MergesDeclarationsAndCurrentValues(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	templateDir := writeVarsTemplate(t, tempDir, map[string]model.VarDef{
+		"enabled": {
+			Type:        model.VarTypeBool,
+			Description: "Enable feature",
+			Required:    true,
+		},
+		"project_name": {
+			Type:        model.VarTypeString,
+			Description: "Project name",
+			Required:    true,
+			Default:     "demo",
+		},
+		"port": {
+			Type:        model.VarTypeInt,
+			Description: "Port",
+			Default:     8080,
+		},
+	})
+	writeProjectConfig(t, templateDir, "main", map[string]interface{}{
+		"enabled": false,
+		"extra":   "local-only",
+		"port":    0,
+	})
+
+	result, err := InspectVars(context.Background(), VarsOptions{})
+	if err != nil {
+		t.Fatalf("InspectVars returned error: %v", err)
+	}
+
+	if !result.DeclarationsAvailable {
+		t.Fatalf("DeclarationsAvailable = false, err = %v", result.DeclarationError)
+	}
+	if result.UnsetCount != 1 {
+		t.Fatalf("UnsetCount = %d, want 1", result.UnsetCount)
+	}
+	if result.RequiredUnsetCount != 1 {
+		t.Fatalf("RequiredUnsetCount = %d, want 1", result.RequiredUnsetCount)
+	}
+
+	rows := varsRowsByName(result.Rows)
+	if rows["enabled"].Unset {
+		t.Fatalf("enabled false value should count as set")
+	}
+	if rows["port"].Unset {
+		t.Fatalf("port zero value should count as set")
+	}
+	if !rows["project_name"].Unset {
+		t.Fatalf("project_name without current value should be unset")
+	}
+	if !rows["extra"].Declared && rows["extra"].Current != "local-only" {
+		t.Fatalf("extra row = %#v, want local-only current value", rows["extra"])
+	}
+}
+
+func TestInspectVars_FetchFailureReturnsLocalOnlyRows(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	writeProjectConfig(t, "./missing-template", "main", map[string]interface{}{
+		"project_name": "demo",
+	})
+
+	result, err := InspectVars(context.Background(), VarsOptions{})
+	if err != nil {
+		t.Fatalf("InspectVars returned error: %v", err)
+	}
+	if result.DeclarationsAvailable {
+		t.Fatalf("DeclarationsAvailable = true, want false")
+	}
+	if result.DeclarationError == nil {
+		t.Fatalf("DeclarationError = nil, want fetch error")
+	}
+	if len(result.Rows) != 1 || result.Rows[0].Name != "project_name" || !result.Rows[0].HasCurrent {
+		t.Fatalf("Rows = %#v, want local project_name row", result.Rows)
+	}
+}
+
+func TestInspectVars_MissingConfigReturnsCheckoutStyleError(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	_, err := InspectVars(context.Background(), VarsOptions{})
+	if err == nil {
+		t.Fatal("InspectVars expected missing config error")
+	}
+	if err.Error() == "" {
+		t.Fatal("InspectVars returned empty error")
+	}
+}
+
+func varsRowsByName(rows []VarsRow) map[string]VarsRow {
+	result := make(map[string]VarsRow, len(rows))
+	for _, row := range rows {
+		result[row.Name] = row
+	}
+	return result
+}
+
+func writeVarsTemplate(t *testing.T, tempDir string, variables map[string]model.VarDef) string {
+	t.Helper()
+
+	templateDir := filepath.Join(tempDir, "template")
+	if err := os.MkdirAll(templateDir, 0755); err != nil {
+		t.Fatalf("failed to create template dir: %v", err)
+	}
+	ignJSON := &model.IgnJson{
+		Name:      "vars-template",
+		Version:   "1.0.0",
+		Hash:      testHash1,
+		Variables: variables,
+	}
+	data, err := json.MarshalIndent(ignJSON, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal template config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(templateDir, model.IgnTemplateConfigFile), data, 0644); err != nil {
+		t.Fatalf("failed to save template config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(templateDir, "README.md"), []byte("hello"), 0644); err != nil {
+		t.Fatalf("failed to write template file: %v", err)
+	}
+	return "./template"
+}
+
+func writeProjectConfig(t *testing.T, templateURL, ref string, vars map[string]interface{}) {
+	t.Helper()
+
+	if err := os.MkdirAll(model.IgnConfigDir, 0755); err != nil {
+		t.Fatalf("failed to create .ign: %v", err)
+	}
+	ignConfig := &model.IgnConfig{
+		Template: model.TemplateSource{URL: templateURL, Ref: ref},
+		Hash:     testHash1,
+	}
+	if err := config.SaveIgnConfig(filepath.Join(model.IgnConfigDir, model.IgnProjectConfigFile), ignConfig); err != nil {
+		t.Fatalf("failed to save ign config: %v", err)
+	}
+	if err := config.SaveIgnVarJson(filepath.Join(model.IgnConfigDir, model.IgnVarFile), &model.IgnVarJson{Variables: vars}); err != nil {
+		t.Fatalf("failed to save ign vars: %v", err)
+	}
+}

--- a/internal/cli/checkout.go
+++ b/internal/cli/checkout.go
@@ -64,7 +64,6 @@ func init() {
 func runCheckout(cmd *cobra.Command, args []string) error {
 	url := args[0]
 	if err := ValidateVariableAssignmentSyntax(checkoutVars); err != nil {
-		printErrorMsg(fmt.Sprintf("Variable parsing failed: %v", err))
 		return err
 	}
 
@@ -81,9 +80,7 @@ func runCheckout(cmd *cobra.Command, args []string) error {
 	if _, err := os.Stat(configDir); err == nil {
 		configExists = true
 		if !checkoutForce {
-			printInfo("Configuration already exists at .ign")
-			printInfo("(use --force to backup and reinitialize)")
-			return nil
+			return fmt.Errorf("configuration already exists at %s (use --force to backup and reinitialize)", configDir)
 		}
 		printWarning("Force mode enabled - will backup existing configuration")
 	}
@@ -108,21 +105,18 @@ func runCheckout(cmd *cobra.Command, args []string) error {
 		SkipConfigSetup: true,
 	})
 	if err != nil {
-		printErrorMsg(fmt.Sprintf("Preparation failed: %v", err))
 		return err
 	}
 
 	resolvedIgnJSON := templatedefaults.ResolveIgnJSON(prepResult.IgnJson, outputPath)
 	providedVars, err := ParseVariableAssignments(checkoutVars, resolvedIgnJSON.Variables)
 	if err != nil {
-		printErrorMsg(fmt.Sprintf("Variable parsing failed: %v", err))
 		return err
 	}
 
 	// Prompt only for variables that were not supplied by flag.
 	vars, err := PromptForVariablesWithProvided(resolvedIgnJSON, providedVars)
 	if err != nil {
-		printErrorMsg(fmt.Sprintf("Variable collection failed: %v", err))
 		return err
 	}
 
@@ -137,7 +131,6 @@ func runCheckout(cmd *cobra.Command, args []string) error {
 	}
 	preparedInputs, err := app.PrepareCompleteCheckoutInputs(completeOpts)
 	if err != nil {
-		printErrorMsg(fmt.Sprintf("Checkout failed: %v", err))
 		return err
 	}
 	completeOpts.PreparedInputs = preparedInputs
@@ -147,7 +140,6 @@ func runCheckout(cmd *cobra.Command, args []string) error {
 		printInfo("[DRY RUN] Would generate project from template")
 	} else {
 		if err := app.PrepareCheckoutConfigDir(configExists); err != nil {
-			printErrorMsg(fmt.Sprintf("Checkout failed: %v", err))
 			return err
 		}
 		printInfo("Generating project from template...")
@@ -155,7 +147,6 @@ func runCheckout(cmd *cobra.Command, args []string) error {
 
 	result, err := app.CompleteCheckout(cmd.Context(), completeOpts)
 	if err != nil {
-		printErrorMsg(fmt.Sprintf("Checkout failed: %v", err))
 		return err
 	}
 

--- a/internal/cli/checkout_test.go
+++ b/internal/cli/checkout_test.go
@@ -108,6 +108,32 @@ func TestRunCheckoutInvalidFileVariableDoesNotBackupExistingConfig(t *testing.T)
 	}
 }
 
+func TestRunCheckoutExistingConfigWithoutForceReturnsError(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
+	if err := os.MkdirAll(model.IgnConfigDir, 0755); err != nil {
+		t.Fatalf("failed to create .ign: %v", err)
+	}
+
+	origForce := checkoutForce
+	origVars := checkoutVars
+	defer func() {
+		checkoutForce = origForce
+		checkoutVars = origVars
+	}()
+	checkoutForce = false
+	checkoutVars = nil
+
+	err := runCheckout(&cobra.Command{}, []string{"github.com/owner/repo"})
+	if err == nil {
+		t.Fatal("runCheckout expected existing config error")
+	}
+	if !strings.Contains(err.Error(), "configuration already exists") {
+		t.Fatalf("error = %v, want existing configuration message", err)
+	}
+}
+
 func TestRunCheckoutInvalidTemplateHashDoesNotBackupExistingConfig(t *testing.T) {
 	tempDir := t.TempDir()
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,6 +1,9 @@
 package cli
 
 import (
+	"errors"
+	"os"
+	"strings"
 	"testing"
 )
 
@@ -71,6 +74,36 @@ func TestValidateGitHubURL(t *testing.T) {
 				t.Errorf("ValidateGitHubURL() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestPrintErrorIgnoresQuiet(t *testing.T) {
+	origQuiet := globalQuiet
+	origStderr := os.Stderr
+	defer func() {
+		globalQuiet = origQuiet
+		os.Stderr = origStderr
+	}()
+
+	readEnd, writeEnd, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stderr pipe: %v", err)
+	}
+	os.Stderr = writeEnd
+	globalQuiet = true
+
+	printError(errors.New("boom"))
+	if err := writeEnd.Close(); err != nil {
+		t.Fatalf("failed to close stderr pipe: %v", err)
+	}
+	buf := make([]byte, 1024)
+	n, err := readEnd.Read(buf)
+	if err != nil {
+		t.Fatalf("failed to read stderr pipe: %v", err)
+	}
+	output := buf[:n]
+	if !strings.Contains(string(output), "Error: boom") {
+		t.Fatalf("stderr = %q, want error output", output)
 	}
 }
 

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+
+	"github.com/tacogips/ign/internal/app"
 )
 
 // Common flag names and descriptions
@@ -82,18 +84,7 @@ func ValidateGitHubURL(url string) (string, error) {
 
 // ValidateGitRef validates a git reference (branch, tag, or commit)
 func ValidateGitRef(ref string) error {
-	if ref == "" {
-		return fmt.Errorf("git reference cannot be empty")
-	}
-
-	// Check if it matches any valid pattern
-	if refBranchPattern.MatchString(ref) ||
-		refTagPattern.MatchString(ref) ||
-		refCommitPattern.MatchString(ref) {
-		return nil
-	}
-
-	return fmt.Errorf("invalid git reference: %s", ref)
+	return app.ValidateGitRef(ref)
 }
 
 // ValidateOutputPath validates an output directory path

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -37,7 +37,6 @@ func init() {
 func runInit(cmd *cobra.Command, args []string) error {
 	url := args[0]
 	if err := ValidateVariableAssignmentSyntax(initVars); err != nil {
-		printErrorMsg(fmt.Sprintf("Variable parsing failed: %v", err))
 		return err
 	}
 
@@ -48,7 +47,6 @@ func runInit(cmd *cobra.Command, args []string) error {
 		configExists = true
 		if !initForce {
 			err := fmt.Errorf("configuration already exists at %s (use --force to reinitialize)", configDir)
-			printErrorMsg(err.Error())
 			return err
 		}
 		printWarning("Force mode enabled - will backup existing configuration")
@@ -70,25 +68,21 @@ func runInit(cmd *cobra.Command, args []string) error {
 		SkipConfigSetup: true,
 	})
 	if err != nil {
-		printErrorMsg(fmt.Sprintf("Initialization failed: %v", err))
 		return err
 	}
 
 	resolvedIgnJSON := templatedefaults.ResolveIgnJSON(prepResult.IgnJson, ".")
 	providedVars, err := ParseVariableAssignments(initVars, resolvedIgnJSON.Variables)
 	if err != nil {
-		printErrorMsg(fmt.Sprintf("Variable parsing failed: %v", err))
 		return err
 	}
 
 	vars, err := PromptForVariablesWithProvided(resolvedIgnJSON, providedVars)
 	if err != nil {
-		printErrorMsg(fmt.Sprintf("Variable collection failed: %v", err))
 		return err
 	}
 
 	if err := app.PrepareCheckoutConfigDir(configExists); err != nil {
-		printErrorMsg(fmt.Sprintf("Initialization failed: %v", err))
 		return err
 	}
 
@@ -97,7 +91,6 @@ func runInit(cmd *cobra.Command, args []string) error {
 		Variables:     vars,
 		GeneratedBy:   "ign init",
 	}); err != nil {
-		printErrorMsg(fmt.Sprintf("Initialization failed: %v", err))
 		return err
 	}
 

--- a/internal/cli/prompt.go
+++ b/internal/cli/prompt.go
@@ -128,6 +128,9 @@ func promptString(name string, varDef model.VarDef, help string) (string, error)
 		validators = append(validators, survey.Required)
 	}
 	if varDef.Pattern != "" {
+		if _, err := regexp.Compile(varDef.Pattern); err != nil {
+			return "", fmt.Errorf("variable %q has invalid pattern %q: %w", name, varDef.Pattern, err)
+		}
 		validators = append(validators, matchPattern(varDef.Pattern, "value must match pattern: "+varDef.Pattern))
 	}
 

--- a/internal/cli/prompt_test.go
+++ b/internal/cli/prompt_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/tacogips/ign/internal/template/model"
@@ -15,6 +16,19 @@ func TestPromptForVariables_NilConfig(t *testing.T) {
 	}
 	if len(vars) != 0 {
 		t.Fatalf("PromptForVariables(nil) = %v, want empty map", vars)
+	}
+}
+
+func TestPromptStringInvalidPatternFailsBeforePrompt(t *testing.T) {
+	_, err := promptString("name", model.VarDef{
+		Type:    model.VarTypeString,
+		Pattern: "[",
+	}, "")
+	if err == nil {
+		t.Fatal("promptString expected invalid pattern error")
+	}
+	if !strings.Contains(err.Error(), `variable "name" has invalid pattern`) {
+		t.Fatalf("error = %v, want variable invalid pattern message", err)
 	}
 }
 

--- a/internal/cli/rewind.go
+++ b/internal/cli/rewind.go
@@ -43,6 +43,9 @@ func runRewind(cmd *cobra.Command, args []string) error {
 		if result.FilesMissing > 0 {
 			printInfo(fmt.Sprintf("  Missing: %d files (already absent)", result.FilesMissing))
 		}
+		if result.FilesSkipped > 0 {
+			printInfo(fmt.Sprintf("  Skipped: %d files (content differs)", result.FilesSkipped))
+		}
 		if result.DirectoriesRemoved > 0 {
 			printInfo(fmt.Sprintf("  Cleaned: %d empty directories", result.DirectoriesRemoved))
 		}
@@ -55,7 +58,6 @@ func runRewind(cmd *cobra.Command, args []string) error {
 	}
 
 	if err != nil {
-		printErrorMsg(fmt.Sprintf("Rewind failed: %v", err))
 		return err
 	}
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -64,8 +64,5 @@ func init() {
 
 // printError prints an error message to stderr
 func printError(err error) {
-	if globalQuiet {
-		return
-	}
 	fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -60,6 +60,7 @@ func init() {
 	rootCmd.AddCommand(switchCmd)
 	rootCmd.AddCommand(templateCmd)
 	rootCmd.AddCommand(versionCmd)
+	rootCmd.AddCommand(varsCmd)
 }
 
 // printError prints an error message to stderr

--- a/internal/cli/switch.go
+++ b/internal/cli/switch.go
@@ -12,6 +12,7 @@ var (
 	switchRef     string
 	switchForce   bool
 	switchVerbose bool
+	switchVars    []string
 )
 
 var switchCmd = &cobra.Command{
@@ -33,10 +34,15 @@ func init() {
 	switchCmd.Flags().StringVarP(&switchRef, "ref", "r", "main", "Git branch, tag, or commit SHA")
 	switchCmd.Flags().BoolVarP(&switchForce, "force", "f", false, "Overwrite existing files when applying the new template")
 	switchCmd.Flags().BoolVarP(&switchVerbose, "verbose", "v", false, "Show detailed processing information")
+	switchCmd.Flags().StringArrayVarP(&switchVars, FlagVar, "V", nil, DescVar)
 }
 
 func runSwitch(cmd *cobra.Command, args []string) error {
 	url := args[0]
+	if err := ValidateVariableAssignmentSyntax(switchVars); err != nil {
+		return err
+	}
+
 	outputPath := "."
 	if len(args) > 1 {
 		outputPath = args[1]
@@ -51,20 +57,25 @@ func runSwitch(cmd *cobra.Command, args []string) error {
 	printInfo(fmt.Sprintf("Output: %s", outputPath))
 
 	prepResult, err := app.PrepareCheckout(cmd.Context(), app.PrepareCheckoutOptions{
-		URL:          url,
-		Ref:          switchRef,
-		Force:        false,
-		ConfigExists: false,
-		GitHubToken:  githubToken,
+		URL:             url,
+		Ref:             switchRef,
+		Force:           false,
+		ConfigExists:    false,
+		GitHubToken:     githubToken,
+		SkipConfigSetup: true,
 	})
 	if err != nil {
-		printErrorMsg(fmt.Sprintf("Switch preparation failed: %v", err))
 		return err
 	}
 
-	vars, err := PromptForVariables(templatedefaults.ResolveIgnJSON(prepResult.IgnJson, outputPath))
+	resolvedIgnJSON := templatedefaults.ResolveIgnJSON(prepResult.IgnJson, outputPath)
+	providedVars, err := ParseVariableAssignments(switchVars, resolvedIgnJSON.Variables)
 	if err != nil {
-		printErrorMsg(fmt.Sprintf("Variable collection failed: %v", err))
+		return err
+	}
+
+	vars, err := PromptForVariablesWithProvided(resolvedIgnJSON, providedVars)
+	if err != nil {
 		return err
 	}
 
@@ -78,7 +89,6 @@ func runSwitch(cmd *cobra.Command, args []string) error {
 		Verbose:       switchVerbose,
 		GitHubToken:   githubToken,
 	}); err != nil {
-		printErrorMsg(fmt.Sprintf("Switch validation failed: %v", err))
 		return err
 	}
 
@@ -87,7 +97,10 @@ func runSwitch(cmd *cobra.Command, args []string) error {
 		OutputDir:   outputPath,
 		GitHubToken: githubToken,
 	}); err != nil {
-		printErrorMsg(fmt.Sprintf("Switch failed during rewind: %v", err))
+		return err
+	}
+
+	if err := app.PrepareCheckoutConfigDir(false); err != nil {
 		return err
 	}
 
@@ -100,7 +113,6 @@ func runSwitch(cmd *cobra.Command, args []string) error {
 		GitHubToken:   githubToken,
 	})
 	if err != nil {
-		printErrorMsg(fmt.Sprintf("Switch failed: %v", err))
 		return err
 	}
 

--- a/internal/cli/switch_test.go
+++ b/internal/cli/switch_test.go
@@ -42,6 +42,7 @@ func TestSwitchCmd_FlagRegistration(t *testing.T) {
 		{"ref", "r"},
 		{"force", "f"},
 		{"verbose", "v"},
+		{FlagVar, "V"},
 	}
 
 	for _, tt := range tests {

--- a/internal/cli/template.go
+++ b/internal/cli/template.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/tacogips/ign/internal/app"
@@ -151,7 +150,6 @@ func runTemplateCheck(cmd *cobra.Command, args []string) error {
 	})
 
 	if err != nil {
-		printErrorMsg(fmt.Sprintf("Template check failed: %v", err))
 		return err
 	}
 
@@ -185,8 +183,7 @@ func runTemplateCheck(cmd *cobra.Command, args []string) error {
 		printSeparator()
 		printErrorMsg(fmt.Sprintf("Validation failed: %d file(s) with errors", result.FilesWithErrors))
 
-		// Exit with error code
-		os.Exit(1)
+		return fmt.Errorf("template validation failed: %d file(s) with errors", result.FilesWithErrors)
 	} else {
 		printSuccess("All templates are valid")
 	}
@@ -211,7 +208,6 @@ func runTemplateNew(cmd *cobra.Command, args []string) error {
 	// Get available types for error message
 	availableTypes, err := app.AvailableScaffoldTypes()
 	if err != nil {
-		printErrorMsg(fmt.Sprintf("Failed to list scaffold types: %v", err))
 		return err
 	}
 
@@ -226,7 +222,6 @@ func runTemplateNew(cmd *cobra.Command, args []string) error {
 	})
 
 	if err != nil {
-		printErrorMsg(fmt.Sprintf("Failed to create template: %v", err))
 		return err
 	}
 
@@ -276,7 +271,6 @@ func runTemplateUpdate(cmd *cobra.Command, args []string) error {
 	})
 
 	if err != nil {
-		printErrorMsg(fmt.Sprintf("Failed to update template: %v", err))
 		return err
 	}
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -97,7 +97,6 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		GitHubToken:   githubToken,
 	})
 	if err != nil {
-		printErrorMsg(fmt.Sprintf("Update preparation failed: %v", err))
 		return err
 	}
 
@@ -162,7 +161,6 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 			printInfo("Please provide values for the following new variables:")
 			promptedVars, err := PromptForNewVariables(varsNeedingPrompt)
 			if err != nil {
-				printErrorMsg(fmt.Sprintf("Failed to collect variable values: %v", err))
 				return err
 			}
 			newVarValues = app.ApplyDefaults(newVarDefs, promptedVars)
@@ -183,7 +181,6 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 			Verbose:       updateVerbose,
 		})
 		if err != nil {
-			printErrorMsg(fmt.Sprintf("Update preview failed: %v", err))
 			return err
 		}
 		printUpdateWritePreview(preview)
@@ -216,7 +213,6 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	})
 
 	if err != nil {
-		printErrorMsg(fmt.Sprintf("Update failed: %v", err))
 		return err
 	}
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -45,6 +45,7 @@ Examples:
   ign update --overwrite         # Selectively overwrite existing files, respecting .ign-overwrite-ignore
   ign update --overwrite --yes   # Selectively overwrite without confirmation
   ign update --overwrite-all     # Overwrite all existing files
+  ign update --ref v2.0.0        # Retarget the tracked template ref non-destructively
   ign update --force             # Regenerate even if unchanged and overwrite all existing files`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runUpdate,
@@ -58,6 +59,7 @@ var (
 	updateDryRun       bool
 	updateVerbose      bool
 	updateYes          bool
+	updateRef          string
 )
 
 func init() {
@@ -70,6 +72,7 @@ func init() {
 	updateCmd.Flags().BoolVarP(&updateDryRun, "dry-run", "d", false, "Preview what files would be generated without writing them")
 	updateCmd.Flags().BoolVarP(&updateVerbose, "verbose", "v", false, "Show detailed processing information during project generation")
 	updateCmd.Flags().BoolVarP(&updateYes, "yes", "y", false, "Skip overwrite confirmation prompt")
+	updateCmd.Flags().StringVarP(&updateRef, "ref", "r", "", "Retarget the tracked template branch, tag, or commit SHA")
 }
 
 func runUpdate(cmd *cobra.Command, args []string) error {
@@ -81,6 +84,12 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 
 	// Get GitHub token from environment
 	githubToken := getGitHubToken("")
+
+	if updateRef != "" {
+		if err := ValidateGitRef(updateRef); err != nil {
+			return fmt.Errorf("invalid update ref: %w", err)
+		}
+	}
 
 	printInfo("Checking for template updates...")
 
@@ -95,6 +104,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		DryRun:        updateDryRun,
 		Verbose:       updateVerbose,
 		GitHubToken:   githubToken,
+		TargetRef:     updateRef,
 	})
 	if err != nil {
 		return err
@@ -102,21 +112,25 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 
 	// Show template info
 	printInfo(fmt.Sprintf("Template: %s", prepResult.IgnConfig.Template.URL))
-	if prepResult.IgnConfig.Template.Ref != "" && prepResult.IgnConfig.Template.Ref != "main" {
+	if prepResult.RefOverrideRequested {
+		printInfo(fmt.Sprintf("Reference: %s", prepResult.RequestedRef))
+	} else if prepResult.IgnConfig.Template.Ref != "" && prepResult.IgnConfig.Template.Ref != "main" {
 		printInfo(fmt.Sprintf("Reference: %s", prepResult.IgnConfig.Template.Ref))
 	}
 	printSeparator()
 
 	// Decide whether to regenerate files.
 	// By default, unchanged template exits early. --overwrite or --force bypasses this.
-	if !shouldRegenerate(prepResult.HashChanged, updateForce, shouldOverwrite) {
+	if !shouldCompleteUpdate(prepResult, updateForce, shouldOverwrite) {
 		printSuccess("Template is up to date (no changes detected)")
 		return nil
 	}
 
 	// Check if hash changed
 	if !prepResult.HashChanged {
-		if updateForce {
+		if prepResult.RefChanged {
+			printInfo("Template content is identical; updating tracked reference...")
+		} else if updateForce {
 			printInfo("Template unchanged, but --force specified - regenerating files...")
 		} else {
 			printInfo("Template unchanged, but --overwrite specified - regenerating files...")
@@ -263,6 +277,13 @@ func shouldRegenerate(hashChanged, force, overwrite bool) bool {
 		return true
 	}
 	return force || overwrite
+}
+
+func shouldCompleteUpdate(prep *app.PrepareUpdateResult, force, overwrite bool) bool {
+	if prep == nil {
+		return false
+	}
+	return shouldRegenerate(prep.HashChanged, force, overwrite) || prep.RefChanged
 }
 
 func updateOverwriteMode(overwrite, overwriteAll, force bool) generator.OverwriteMode {

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/tacogips/ign/internal/app"
 	"github.com/tacogips/ign/internal/template/generator"
 )
 
@@ -15,6 +16,7 @@ func TestUpdateCmd_FlagDefaults(t *testing.T) {
 	updateDryRun = false
 	updateVerbose = false
 	updateYes = false
+	updateRef = ""
 
 	// Verify default values
 	if updateForce != false {
@@ -32,6 +34,9 @@ func TestUpdateCmd_FlagDefaults(t *testing.T) {
 	if updateVerbose != false {
 		t.Errorf("Expected updateVerbose default to be false, got %v", updateVerbose)
 	}
+	if updateRef != "" {
+		t.Errorf("Expected updateRef default to be empty, got %q", updateRef)
+	}
 }
 
 func TestUpdateCmd_FlagRegistration(t *testing.T) {
@@ -46,6 +51,7 @@ func TestUpdateCmd_FlagRegistration(t *testing.T) {
 		{"dry-run", "d"},
 		{"verbose", "v"},
 		{"yes", "y"},
+		{"ref", "r"},
 	}
 
 	for _, tt := range tests {
@@ -193,6 +199,51 @@ func TestShouldRegenerate(t *testing.T) {
 	}
 }
 
+func TestShouldCompleteUpdateIncludesRefChanged(t *testing.T) {
+	tests := []struct {
+		name      string
+		prep      *app.PrepareUpdateResult
+		force     bool
+		overwrite bool
+		want      bool
+	}{
+		{
+			name: "nil prep",
+			want: false,
+		},
+		{
+			name: "unchanged no ref",
+			prep: &app.PrepareUpdateResult{},
+			want: false,
+		},
+		{
+			name: "ref changed",
+			prep: &app.PrepareUpdateResult{RefChanged: true},
+			want: true,
+		},
+		{
+			name: "hash changed",
+			prep: &app.PrepareUpdateResult{HashChanged: true},
+			want: true,
+		},
+		{
+			name:  "force",
+			prep:  &app.PrepareUpdateResult{},
+			force: true,
+			want:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldCompleteUpdate(tt.prep, tt.force, tt.overwrite)
+			if got != tt.want {
+				t.Fatalf("shouldCompleteUpdate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestUpdateCmd_FlagParsing(t *testing.T) {
 	tests := []struct {
 		name                 string
@@ -202,6 +253,7 @@ func TestUpdateCmd_FlagParsing(t *testing.T) {
 		expectedOverwriteAll bool
 		expectedDryRun       bool
 		expectedYes          bool
+		expectedRef          string
 	}{
 		{
 			name:                 "no flags",
@@ -211,6 +263,7 @@ func TestUpdateCmd_FlagParsing(t *testing.T) {
 			expectedOverwriteAll: false,
 			expectedDryRun:       false,
 			expectedYes:          false,
+			expectedRef:          "",
 		},
 		{
 			name:                 "force flag long",
@@ -220,6 +273,7 @@ func TestUpdateCmd_FlagParsing(t *testing.T) {
 			expectedOverwriteAll: false,
 			expectedDryRun:       false,
 			expectedYes:          false,
+			expectedRef:          "",
 		},
 		{
 			name:                 "force flag short",
@@ -229,6 +283,7 @@ func TestUpdateCmd_FlagParsing(t *testing.T) {
 			expectedOverwriteAll: false,
 			expectedDryRun:       false,
 			expectedYes:          false,
+			expectedRef:          "",
 		},
 		{
 			name:                 "overwrite flag long",
@@ -238,6 +293,7 @@ func TestUpdateCmd_FlagParsing(t *testing.T) {
 			expectedOverwriteAll: false,
 			expectedDryRun:       false,
 			expectedYes:          false,
+			expectedRef:          "",
 		},
 		{
 			name:                 "overwrite flag short",
@@ -247,6 +303,7 @@ func TestUpdateCmd_FlagParsing(t *testing.T) {
 			expectedOverwriteAll: false,
 			expectedDryRun:       false,
 			expectedYes:          false,
+			expectedRef:          "",
 		},
 		{
 			name:                 "overwrite all flag",
@@ -256,6 +313,7 @@ func TestUpdateCmd_FlagParsing(t *testing.T) {
 			expectedOverwriteAll: true,
 			expectedDryRun:       false,
 			expectedYes:          false,
+			expectedRef:          "",
 		},
 		{
 			name:                 "force and overwrite combined",
@@ -265,6 +323,7 @@ func TestUpdateCmd_FlagParsing(t *testing.T) {
 			expectedOverwriteAll: false,
 			expectedDryRun:       false,
 			expectedYes:          false,
+			expectedRef:          "",
 		},
 		{
 			name:                 "all flags",
@@ -274,6 +333,27 @@ func TestUpdateCmd_FlagParsing(t *testing.T) {
 			expectedOverwriteAll: true,
 			expectedDryRun:       true,
 			expectedYes:          true,
+			expectedRef:          "",
+		},
+		{
+			name:                 "ref flag long",
+			args:                 []string{"--ref", "v2.0.0"},
+			expectedForce:        false,
+			expectedOverwrite:    false,
+			expectedOverwriteAll: false,
+			expectedDryRun:       false,
+			expectedYes:          false,
+			expectedRef:          "v2.0.0",
+		},
+		{
+			name:                 "ref flag short",
+			args:                 []string{"-r", "feature/new-template"},
+			expectedForce:        false,
+			expectedOverwrite:    false,
+			expectedOverwriteAll: false,
+			expectedDryRun:       false,
+			expectedYes:          false,
+			expectedRef:          "feature/new-template",
 		},
 	}
 
@@ -282,12 +362,14 @@ func TestUpdateCmd_FlagParsing(t *testing.T) {
 			// Create a fresh command for each test to avoid flag state pollution
 			cmd := &cobra.Command{Use: "update"}
 			var force, overwrite, overwriteAll, dryRun, verbose, yes bool
+			var ref string
 			cmd.Flags().BoolVarP(&force, "force", "f", false, "")
 			cmd.Flags().BoolVarP(&overwrite, "overwrite", "o", false, "")
 			cmd.Flags().BoolVar(&overwriteAll, "overwrite-all", false, "")
 			cmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "")
 			cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "")
 			cmd.Flags().BoolVarP(&yes, "yes", "y", false, "")
+			cmd.Flags().StringVarP(&ref, "ref", "r", "", "")
 
 			// Parse the arguments
 			if err := cmd.ParseFlags(tt.args); err != nil {
@@ -308,6 +390,9 @@ func TestUpdateCmd_FlagParsing(t *testing.T) {
 			}
 			if yes != tt.expectedYes {
 				t.Errorf("yes = %v, expected %v", yes, tt.expectedYes)
+			}
+			if ref != tt.expectedRef {
+				t.Errorf("ref = %q, expected %q", ref, tt.expectedRef)
 			}
 		})
 	}

--- a/internal/cli/vars.go
+++ b/internal/cli/vars.go
@@ -1,0 +1,126 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"github.com/tacogips/ign/internal/app"
+)
+
+var (
+	varsJSON  bool
+	varsUnset bool
+)
+
+var errRequiredVarsUnset = errors.New("required template variables are unset")
+
+var varsCmd = &cobra.Command{
+	Use:   "vars",
+	Short: "Inspect template variables and current values",
+	Long: `Inspect template variable declarations and current values from .ign/ign-var.json.
+
+The default output is a table with NAME, TYPE, REQUIRED, DEFAULT, CURRENT, and
+DESCRIPTION columns. Use --json for scripting and --unset to show only variables
+without a current value.`,
+	Args: cobra.NoArgs,
+	RunE: runVars,
+}
+
+func init() {
+	varsCmd.Flags().BoolVar(&varsJSON, "json", false, "Print variables as JSON")
+	varsCmd.Flags().BoolVar(&varsUnset, "unset", false, "Show only variables without a current value")
+}
+
+func runVars(cmd *cobra.Command, args []string) error {
+	result, err := app.InspectVars(cmd.Context(), app.VarsOptions{
+		GitHubToken: getGitHubToken(""),
+	})
+	if err != nil {
+		return err
+	}
+
+	if varsUnset {
+		result = app.FilterUnsetVars(result)
+	}
+
+	if !globalQuiet {
+		if varsJSON {
+			if result.DeclarationError != nil {
+				printVarsWarning(cmd.ErrOrStderr(), result.DeclarationError)
+			}
+			if err := printVarsJSON(cmd.OutOrStdout(), result); err != nil {
+				return err
+			}
+		} else {
+			if result.DeclarationError != nil {
+				printVarsWarning(cmd.ErrOrStderr(), result.DeclarationError)
+			}
+			if err := printVarsTable(cmd.OutOrStdout(), result); err != nil {
+				return err
+			}
+		}
+	}
+
+	if varsUnset && result.RequiredUnsetCount > 0 {
+		return errRequiredVarsUnset
+	}
+
+	return nil
+}
+
+func printVarsWarning(w io.Writer, err error) {
+	if err == nil || globalQuiet {
+		return
+	}
+	fmt.Fprintf(w, "Warning: template declarations unavailable; showing local values only: %v\n", err)
+}
+
+func printVarsJSON(w io.Writer, result *app.VarsResult) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(result)
+}
+
+func printVarsTable(w io.Writer, result *app.VarsResult) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "NAME\tTYPE\tREQUIRED\tDEFAULT\tCURRENT\tDESCRIPTION"); err != nil {
+		return err
+	}
+	for _, row := range result.Rows {
+		if _, err := fmt.Fprintf(
+			tw,
+			"%s\t%s\t%s\t%s\t%s\t%s\n",
+			row.Name,
+			row.Type,
+			formatBool(row.Required),
+			formatVarsValue(row.Default, row.Default != nil),
+			formatVarsValue(row.Current, row.HasCurrent),
+			strings.TrimSpace(row.Description),
+		); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+func formatBool(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
+}
+
+func formatVarsValue(value interface{}, hasValue bool) string {
+	if !hasValue {
+		return ""
+	}
+	if value == nil {
+		return "null"
+	}
+	return strings.TrimSpace(fmt.Sprint(value))
+}

--- a/internal/cli/vars_test.go
+++ b/internal/cli/vars_test.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/tacogips/ign/internal/app"
+)
+
+func TestVarsCmd_FlagRegistration(t *testing.T) {
+	if rootCmd.CommandPath() == "" {
+		t.Fatal("root command is not initialized")
+	}
+	if varsCmd.Flags().Lookup("json") == nil {
+		t.Fatal("vars --json flag is not registered")
+	}
+	if varsCmd.Flags().Lookup("unset") == nil {
+		t.Fatal("vars --unset flag is not registered")
+	}
+}
+
+func TestPrintVarsTable(t *testing.T) {
+	result := &app.VarsResult{
+		DeclarationsAvailable: true,
+		Rows: []app.VarsRow{
+			{Name: "project_name", Type: "string", Required: true, Default: "demo", Current: "current", HasCurrent: true, Description: "Project name", Declared: true},
+		},
+	}
+
+	var out bytes.Buffer
+	if err := printVarsTable(&out, result); err != nil {
+		t.Fatalf("printVarsTable returned error: %v", err)
+	}
+
+	got := out.String()
+	for _, want := range []string{"NAME", "TYPE", "REQUIRED", "DEFAULT", "CURRENT", "DESCRIPTION", "project_name", "current"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("table output %q does not contain %q", got, want)
+		}
+	}
+}
+
+func TestPrintVarsJSONIsScriptSafe(t *testing.T) {
+	result := &app.VarsResult{
+		DeclarationsAvailable: false,
+		Rows: []app.VarsRow{
+			{Name: "project_name", Current: "demo", HasCurrent: true},
+		},
+		UnsetCount: 0,
+	}
+
+	var out bytes.Buffer
+	if err := printVarsJSON(&out, result); err != nil {
+		t.Fatalf("printVarsJSON returned error: %v", err)
+	}
+
+	var decoded app.VarsResult
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatalf("JSON output did not parse: %v\n%s", err, out.String())
+	}
+	if decoded.Rows[0].Name != "project_name" {
+		t.Fatalf("decoded rows = %#v", decoded.Rows)
+	}
+}
+
+func TestVarsUnsetRequiredError(t *testing.T) {
+	result := app.FilterUnsetVars(&app.VarsResult{
+		Rows: []app.VarsRow{
+			{Name: "project_name", Required: true, Unset: true, Declared: true},
+			{Name: "port", Required: false, HasCurrent: true, Declared: true},
+		},
+		UnsetCount:         1,
+		RequiredUnsetCount: 1,
+	})
+
+	if result.RequiredUnsetCount != 1 {
+		t.Fatalf("RequiredUnsetCount = %d, want 1", result.RequiredUnsetCount)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/tacogips/ign/internal/template/model"
@@ -340,6 +341,29 @@ func TestSaveIgnVarJson(t *testing.T) {
 
 	if loaded.Variables["name"] != ignVar.Variables["name"] {
 		t.Errorf("Variables mismatch after save/load")
+	}
+}
+
+func TestSaveIgnConfigUsesAtomicTempFileCleanup(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "build", "ign.json")
+	ignConfig := &model.IgnConfig{
+		Template: model.TemplateSource{URL: "https://github.com/owner/repo"},
+		Hash:     "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+	}
+
+	if err := SaveIgnConfig(configPath, ignConfig); err != nil {
+		t.Fatalf("SaveIgnConfig failed: %v", err)
+	}
+
+	entries, err := os.ReadDir(filepath.Dir(configPath))
+	if err != nil {
+		t.Fatalf("ReadDir failed: %v", err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".ign.json.tmp-") {
+			t.Fatalf("temporary atomic write file was not cleaned up: %s", entry.Name())
+		}
 	}
 }
 

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -163,7 +164,7 @@ func SaveIgnVarJson(path string, ignVar *model.IgnVarJson) error {
 		return NewConfigErrorWithCause(ConfigInvalid, cleanPath, "failed to marshal ign-var.json", err)
 	}
 
-	if err := os.WriteFile(cleanPath, data, 0644); err != nil {
+	if err := writeFileAtomic(cleanPath, data, 0644); err != nil {
 		return NewConfigErrorWithCause(ConfigInvalid, cleanPath, "failed to write ign-var.json", err)
 	}
 
@@ -197,7 +198,7 @@ func SaveIgnManifest(path string, manifest *model.IgnManifest) error {
 		return NewConfigErrorWithCause(ConfigInvalid, cleanPath, "failed to marshal ign-files.json", err)
 	}
 
-	if err := os.WriteFile(cleanPath, data, 0644); err != nil {
+	if err := writeFileAtomic(cleanPath, data, 0644); err != nil {
 		return NewConfigErrorWithCause(ConfigInvalid, cleanPath, "failed to write ign-files.json", err)
 	}
 
@@ -279,10 +280,61 @@ func SaveIgnConfig(path string, ignConfig *model.IgnConfig) error {
 		return NewConfigErrorWithCause(ConfigInvalid, cleanPath, "failed to marshal ign.json", err)
 	}
 
-	if err := os.WriteFile(cleanPath, data, 0644); err != nil {
+	if err := writeFileAtomic(cleanPath, data, 0644); err != nil {
 		return NewConfigErrorWithCause(ConfigInvalid, cleanPath, "failed to write ign.json", err)
 	}
 
+	return nil
+}
+
+// WriteFileAtomic writes data to path using a same-directory temporary file and rename.
+func WriteFileAtomic(path string, data []byte, perm os.FileMode) error {
+	return writeFileAtomic(path, data, perm)
+}
+
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tempFile, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tempPath := tempFile.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tempPath)
+		}
+	}()
+
+	if _, err := tempFile.Write(data); err != nil {
+		_ = tempFile.Close()
+		return err
+	}
+	if err := tempFile.Chmod(perm); err != nil {
+		_ = tempFile.Close()
+		return err
+	}
+	if err := tempFile.Sync(); err != nil {
+		_ = tempFile.Close()
+		return err
+	}
+	if err := tempFile.Close(); err != nil {
+		return err
+	}
+
+	if err := os.Rename(tempPath, path); err != nil {
+		return err
+	}
+	cleanup = false
+
+	dirFile, err := os.Open(dir)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = dirFile.Close() }()
+	if err := dirFile.Sync(); err != nil && err != io.ErrClosedPipe {
+		return err
+	}
 	return nil
 }
 

--- a/internal/template/generator/generator_test.go
+++ b/internal/template/generator/generator_test.go
@@ -40,6 +40,48 @@ func TestIsSpecialFile(t *testing.T) {
 	}
 }
 
+func TestGeneratorResolvesRelativeIncludeFromTemplateFileDirectory(t *testing.T) {
+	tempDir := t.TempDir()
+	template := &model.Template{
+		RootPath: tempDir,
+		Config: model.IgnJson{
+			Name:      "include-template",
+			Version:   "1.0.0",
+			Variables: map[string]model.VarDef{},
+		},
+		Files: []model.TemplateFile{
+			{Path: "_includes/header.txt", Content: []byte("included\n")},
+			{Path: "cmd/main.txt", Content: []byte("@ign-include:../_includes/header.txt@body\n")},
+		},
+	}
+	if err := os.MkdirAll(filepath.Join(tempDir, "_includes"), 0755); err != nil {
+		t.Fatalf("failed to create template include dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, "_includes", "header.txt"), []byte("included\n"), 0644); err != nil {
+		t.Fatalf("failed to write include file: %v", err)
+	}
+
+	gen := NewGenerator()
+	result, err := gen.DryRun(context.Background(), GenerateOptions{
+		Template:  template,
+		Variables: parser.NewMapVariables(map[string]interface{}{}),
+		OutputDir: filepath.Join(tempDir, "out"),
+	})
+	if err != nil {
+		t.Fatalf("DryRun failed: %v", err)
+	}
+
+	for _, file := range result.DryRunFiles {
+		if filepath.Base(file.Path) == "main.txt" {
+			if string(file.Content) != "included\nbody\n" {
+				t.Fatalf("main content = %q, want included content", file.Content)
+			}
+			return
+		}
+	}
+	t.Fatal("main.txt dry-run output not found")
+}
+
 // TestMatchesPattern tests glob pattern matching.
 func TestMatchesPattern(t *testing.T) {
 	tests := []struct {

--- a/internal/template/generator/processor.go
+++ b/internal/template/generator/processor.go
@@ -117,7 +117,7 @@ func (p *FileProcessor) Process(ctx context.Context, file model.TemplateFile, va
 		IncludeDepth: 0,
 		IncludeStack: []string{},
 		TemplateRoot: templateRoot,
-		CurrentFile:  file.Path,
+		CurrentFile:  filepath.Join(templateRoot, file.Path),
 	}
 
 	// Process template directives

--- a/internal/template/parser/directive.go
+++ b/internal/template/parser/directive.go
@@ -75,7 +75,7 @@ var (
 	// The trick: content should match up to and including embedded directives
 	// Example: @ign-raw:@ign-var:name@@ has content "@ign-var:name@" and closes with final @
 	// We use non-greedy (.*?) followed by @ to capture content, then match the closing @
-	rawDirectivePattern = regexp.MustCompile(`@ign-raw:(.*@)@`)
+	rawDirectivePattern = regexp.MustCompile(`@ign-raw:(.*?@)@`)
 )
 
 // findDirectives scans input and returns all directive matches in order.

--- a/internal/template/parser/include.go
+++ b/internal/template/parser/include.go
@@ -98,11 +98,6 @@ func processIncludes(ctx context.Context, input []byte, pctx *ParseContext) ([]b
 // - Relative paths: relative to current file's directory
 // - Absolute paths (starting with /): relative to template root
 func resolveIncludePath(includePath, templateRoot, currentFile string) (string, error) {
-	// Validate path doesn't contain ..
-	if strings.Contains(includePath, "..") {
-		return "", fmt.Errorf("include path contains '..': %s", includePath)
-	}
-
 	var resolvedPath string
 
 	if filepath.IsAbs(includePath) || strings.HasPrefix(includePath, "/") {
@@ -110,15 +105,19 @@ func resolveIncludePath(includePath, templateRoot, currentFile string) (string, 
 		resolvedPath = filepath.Join(templateRoot, strings.TrimPrefix(includePath, "/"))
 	} else {
 		// Relative path (from current file's directory)
+		if !filepath.IsAbs(currentFile) {
+			currentFile = filepath.Join(templateRoot, currentFile)
+		}
 		currentDir := filepath.Dir(currentFile)
 		resolvedPath = filepath.Join(currentDir, includePath)
 	}
 
-	// Clean the path
 	resolvedPath = filepath.Clean(resolvedPath)
+	templateRoot = filepath.Clean(templateRoot)
 
 	// Verify the resolved path is within template root
-	if !strings.HasPrefix(resolvedPath, templateRoot) {
+	rel, err := filepath.Rel(templateRoot, resolvedPath)
+	if err != nil || filepath.IsAbs(rel) || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return "", fmt.Errorf("include path escapes template root: %s", includePath)
 	}
 

--- a/internal/template/parser/parser_test.go
+++ b/internal/template/parser/parser_test.go
@@ -201,6 +201,12 @@ func TestRawDirective(t *testing.T) {
 			vars:     map[string]interface{}{"name": "myapp"},
 			expected: "Project: myapp, Syntax: @ign-var:x@",
 		},
+		{
+			name:     "two raw directives on one line",
+			input:    "@ign-raw:@a@@ mid @ign-raw:@b@@",
+			vars:     map[string]interface{}{},
+			expected: "@a@ mid @b@",
+		},
 	}
 
 	parser := NewParser()
@@ -343,6 +349,41 @@ func TestIncludeDirective(t *testing.T) {
 	expected := "// Header: myapp\n\ncode here"
 	if string(result) != expected {
 		t.Errorf("expected %q, got %q", expected, string(result))
+	}
+}
+
+func TestIncludeDirectiveRejectsSiblingPrefixEscape(t *testing.T) {
+	tmpDir := t.TempDir()
+	templateRoot := filepath.Join(tmpDir, "template")
+	sibling := filepath.Join(tmpDir, "template-other")
+	if err := os.MkdirAll(templateRoot, 0755); err != nil {
+		t.Fatalf("failed to create template root: %v", err)
+	}
+	if err := os.MkdirAll(sibling, 0755); err != nil {
+		t.Fatalf("failed to create sibling dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(templateRoot, "sub"), 0755); err != nil {
+		t.Fatalf("failed to create template subdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sibling, "secret.txt"), []byte("secret"), 0644); err != nil {
+		t.Fatalf("failed to write sibling include: %v", err)
+	}
+
+	pctx := &ParseContext{
+		Variables:    testVars(map[string]interface{}{}),
+		IncludeDepth: 0,
+		IncludeStack: []string{},
+		TemplateRoot: templateRoot,
+		CurrentFile:  filepath.Join(templateRoot, "sub", "main.txt"),
+	}
+
+	parser := NewParser()
+	_, err := parser.ParseWithContext(context.Background(), []byte("@ign-include:../../template-other/secret.txt@"), pctx)
+	if err == nil {
+		t.Fatal("expected include escape error")
+	}
+	if !strings.Contains(err.Error(), "escapes template root") {
+		t.Fatalf("error = %v, want template root escape rejection", err)
 	}
 }
 

--- a/internal/template/provider/github.go
+++ b/internal/template/provider/github.go
@@ -301,9 +301,17 @@ func (p *GitHubProvider) extractArchive(archivePath string) (string, error) {
 			debug.Debug("[github] Archive root directory: %s", rootDir)
 		}
 		relPath := parts[1]
+		if relPath == "" {
+			continue
+		}
 
 		// Construct target path
-		target := filepath.Join(extractDir, relPath)
+		target, err := safeArchiveTarget(extractDir, relPath)
+		if err != nil {
+			_ = os.RemoveAll(extractDir)
+			debug.Debug("[github] Unsafe archive entry %s: %v", header.Name, err)
+			return "", err
+		}
 
 		switch header.Typeflag {
 		case tar.TypeDir:
@@ -347,6 +355,12 @@ func (p *GitHubProvider) extractArchive(archivePath string) (string, error) {
 			_ = outFile.Close()
 			fileCount++
 		case tar.TypeSymlink:
+			if err := validateArchiveSymlinkTarget(extractDir, target, header.Linkname); err != nil {
+				_ = os.RemoveAll(extractDir)
+				debug.Debug("[github] Unsafe archive symlink %s -> %s: %v", target, header.Linkname, err)
+				return "", err
+			}
+
 			// Create parent directory if needed
 			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
 				_ = os.RemoveAll(extractDir)
@@ -373,6 +387,34 @@ func (p *GitHubProvider) extractArchive(archivePath string) (string, error) {
 
 	debug.Debug("[github] Extracted %d files and %d directories", fileCount, dirCount)
 	return extractDir, nil
+}
+
+func safeArchiveTarget(extractDir, relPath string) (string, error) {
+	if relPath == "" {
+		return "", fmt.Errorf("archive entry path is empty")
+	}
+	if filepath.IsAbs(relPath) {
+		return "", fmt.Errorf("archive entry path is absolute: %s", relPath)
+	}
+	target := filepath.Clean(filepath.Join(extractDir, relPath))
+	if !isSubPath(extractDir, target) {
+		return "", fmt.Errorf("archive entry escapes extraction directory: %s", relPath)
+	}
+	return target, nil
+}
+
+func validateArchiveSymlinkTarget(extractDir, target, linkName string) error {
+	if linkName == "" {
+		return fmt.Errorf("archive symlink target is empty")
+	}
+	if filepath.IsAbs(linkName) {
+		return fmt.Errorf("archive symlink target is absolute: %s", linkName)
+	}
+	resolved := filepath.Clean(filepath.Join(filepath.Dir(target), linkName))
+	if !isSubPath(extractDir, resolved) {
+		return fmt.Errorf("archive symlink target escapes extraction directory: %s", linkName)
+	}
+	return nil
 }
 
 // removeExistingArchiveEntry removes an existing filesystem entry at path.

--- a/internal/template/provider/github_test.go
+++ b/internal/template/provider/github_test.go
@@ -111,6 +111,83 @@ func TestGitHubProvider_ExtractArchive_SymlinkReplacesExistingFile(t *testing.T)
 	}
 }
 
+func TestGitHubProvider_ExtractArchiveRejectsEscapingEntry(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	archivePath := filepath.Join(tmpDir, "template-escape.tar.gz")
+	if err := createTestArchive(archivePath, []archiveEntry{
+		{header: &tar.Header{Name: "repo-main/", Typeflag: tar.TypeDir, Mode: 0755}},
+		{
+			header:  &tar.Header{Name: "repo-main/../../escape.txt", Typeflag: tar.TypeReg, Mode: 0644, Size: int64(len("escape"))},
+			content: []byte("escape"),
+		},
+	}); err != nil {
+		t.Fatalf("failed to create test archive: %v", err)
+	}
+
+	p := NewGitHubProvider()
+	if _, err := p.extractArchive(archivePath); err == nil {
+		t.Fatal("extractArchive expected escaping entry error")
+	}
+}
+
+func TestGitHubProvider_ExtractArchiveRejectsEscapingSymlink(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	archivePath := filepath.Join(tmpDir, "template-symlink-escape.tar.gz")
+	if err := createTestArchive(archivePath, []archiveEntry{
+		{header: &tar.Header{Name: "repo-main/", Typeflag: tar.TypeDir, Mode: 0755}},
+		{
+			header: &tar.Header{
+				Name:     "repo-main/link",
+				Typeflag: tar.TypeSymlink,
+				Mode:     0777,
+				Linkname: "../outside",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("failed to create test archive: %v", err)
+	}
+
+	p := NewGitHubProvider()
+	if _, err := p.extractArchive(archivePath); err == nil {
+		t.Fatal("extractArchive expected escaping symlink error")
+	}
+}
+
+type archiveEntry struct {
+	header  *tar.Header
+	content []byte
+}
+
+func createTestArchive(archivePath string, entries []archiveEntry) error {
+	f, err := os.Create(archivePath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	gzw := gzip.NewWriter(f)
+	defer func() { _ = gzw.Close() }()
+
+	tw := tar.NewWriter(gzw)
+	defer func() { _ = tw.Close() }()
+
+	for _, e := range entries {
+		if err := tw.WriteHeader(e.header); err != nil {
+			return err
+		}
+		if len(e.content) > 0 {
+			if _, err := tw.Write(e.content); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 func createTestTemplateArchiveWithSymlink(archivePath string) error {
 	f, err := os.Create(archivePath)
 	if err != nil {

--- a/internal/template/provider/provider_test.go
+++ b/internal/template/provider/provider_test.go
@@ -38,6 +38,29 @@ func TestParseGitHubURL(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "https URL tree branch only",
+			url:  "https://github.com/owner/repo/tree/develop",
+			want: &model.TemplateRef{
+				Provider: "github",
+				Owner:    "owner",
+				Repo:     "repo",
+				Path:     "",
+				Ref:      "develop",
+			},
+			wantErr: false,
+		},
+		{
+			name: "https URL trims git suffix",
+			url:  "https://github.com/owner/repo.git",
+			want: &model.TemplateRef{
+				Provider: "github",
+				Owner:    "owner",
+				Repo:     "repo",
+				Ref:      "main",
+			},
+			wantErr: false,
+		},
+		{
 			name: "git@ SSH URL",
 			url:  "git@github.com:owner/repo.git",
 			want: &model.TemplateRef{

--- a/internal/template/provider/url.go
+++ b/internal/template/provider/url.go
@@ -43,17 +43,20 @@ func ParseGitHubURL(url string) (*model.TemplateRef, error) {
 			if len(parts) > 1 {
 				branchPath := parts[1]
 				slashIdx := strings.Index(branchPath, "/")
+				ref2, err := parseOwnerRepoPath(ownerRepo)
+				if err != nil {
+					return nil, err
+				}
 				if slashIdx != -1 {
 					ref := branchPath[:slashIdx]
 					path := branchPath[slashIdx+1:]
-					ref2, err := parseOwnerRepoPath(ownerRepo)
-					if err != nil {
-						return nil, err
-					}
 					ref2.Ref = ref
 					ref2.Path = path
 					return ref2, nil
 				}
+				ref2.Ref = branchPath
+				ref2.Path = ""
+				return ref2, nil
 			}
 		}
 		return parseOwnerRepoPath(url)
@@ -83,7 +86,7 @@ func parseOwnerRepoPath(s string) (*model.TemplateRef, error) {
 	}
 
 	owner := parts[0]
-	repo := parts[1]
+	repo := strings.TrimSuffix(parts[1], ".git")
 
 	if owner == "" || repo == "" {
 		return nil, fmt.Errorf("owner and repo cannot be empty: %s", s)

--- a/test/integration/update_ref_test.go
+++ b/test/integration/update_ref_test.go
@@ -1,0 +1,364 @@
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tacogips/ign/internal/app"
+	"github.com/tacogips/ign/internal/config"
+	"github.com/tacogips/ign/internal/template/model"
+)
+
+func TestUpdateRefRetargetsTemplateAndPersistsRef(t *testing.T) {
+	tempDir := t.TempDir()
+	templatePath := copyFixtureToTemp(t, "simple-template", tempDir)
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current directory: %v", err)
+	}
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("failed to change to temp directory: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	if err := app.Init(context.Background(), app.InitOptions{URL: templatePath}); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	seedSimpleTemplateVars(t)
+
+	prep, err := app.PrepareUpdate(context.Background(), app.UpdateOptions{
+		OutputDir: ".",
+		TargetRef: "v2.0.0",
+	})
+	if err != nil {
+		t.Fatalf("PrepareUpdate failed: %v", err)
+	}
+	if !prep.RefChanged {
+		t.Fatal("RefChanged = false, want true")
+	}
+
+	if _, err := app.CompleteUpdate(context.Background(), app.CompleteUpdateOptions{
+		PrepareResult: prep,
+		OutputDir:     ".",
+	}); err != nil {
+		t.Fatalf("CompleteUpdate failed: %v", err)
+	}
+
+	loaded, err := config.LoadIgnConfig(filepath.Join(model.IgnConfigDir, model.IgnProjectConfigFile))
+	if err != nil {
+		t.Fatalf("failed to load ign config: %v", err)
+	}
+	if loaded.Template.Ref != "v2.0.0" {
+		t.Fatalf("stored ref = %q, want v2.0.0", loaded.Template.Ref)
+	}
+}
+
+func TestUpdateRefDryRunDoesNotPersistRef(t *testing.T) {
+	tempDir := t.TempDir()
+	templatePath := copyFixtureToTemp(t, "simple-template", tempDir)
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current directory: %v", err)
+	}
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("failed to change to temp directory: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	if err := app.Init(context.Background(), app.InitOptions{URL: templatePath}); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	seedSimpleTemplateVars(t)
+
+	prep, err := app.PrepareUpdate(context.Background(), app.UpdateOptions{
+		OutputDir: ".",
+		TargetRef: "v2.0.0",
+	})
+	if err != nil {
+		t.Fatalf("PrepareUpdate failed: %v", err)
+	}
+
+	if _, err := app.CompleteUpdate(context.Background(), app.CompleteUpdateOptions{
+		PrepareResult: prep,
+		OutputDir:     ".",
+		DryRun:        true,
+	}); err != nil {
+		t.Fatalf("CompleteUpdate dry-run failed: %v", err)
+	}
+
+	loaded, err := config.LoadIgnConfig(filepath.Join(model.IgnConfigDir, model.IgnProjectConfigFile))
+	if err != nil {
+		t.Fatalf("failed to load ign config: %v", err)
+	}
+	if loaded.Template.Ref != "" {
+		t.Fatalf("stored ref = %q, want unchanged empty ref", loaded.Template.Ref)
+	}
+}
+
+func TestUpdateRefCLIUpdatesGeneratedFilesAndPersistsRef(t *testing.T) {
+	tempDir := t.TempDir()
+	templatePath := filepath.Join(tempDir, "template")
+	writeUpdateRefTemplate(t, templatePath, updateRefTemplateSpec{
+		Hash:  updateRefHash1,
+		Files: map[string]string{"README.md": "version one\n"},
+	})
+	ignBinary := buildIgnBinary(t)
+
+	withWorkingDir(t, tempDir, func() {
+		if err := app.Init(context.Background(), app.InitOptions{URL: "./template"}); err != nil {
+			t.Fatalf("Init failed: %v", err)
+		}
+		if _, err := app.Checkout(context.Background(), app.CheckoutOptions{OutputDir: "."}); err != nil {
+			t.Fatalf("Checkout failed: %v", err)
+		}
+
+		writeUpdateRefTemplate(t, templatePath, updateRefTemplateSpec{
+			Hash:  updateRefHash2,
+			Files: map[string]string{"README.md": "version two\n"},
+		})
+
+		result := runIgnCLI(t, ignBinary, tempDir, "update", "--ref", "v2.0.0", "--overwrite-all", "--yes")
+		if result.exitCode != 0 {
+			t.Fatalf("ign update --ref exit = %d, stderr = %s", result.exitCode, result.stderr)
+		}
+
+		if got := readFileString(t, filepath.Join(tempDir, "README.md")); got != "version two\n" {
+			t.Fatalf("README.md = %q, want updated template content", got)
+		}
+		assertStoredUpdateRef(t, "v2.0.0")
+	})
+}
+
+func TestUpdateRefCLIIdenticalContentPersistsRefWithoutRewritingFiles(t *testing.T) {
+	tempDir := t.TempDir()
+	templatePath := filepath.Join(tempDir, "template")
+	writeUpdateRefTemplate(t, templatePath, updateRefTemplateSpec{
+		Hash:  updateRefHash1,
+		Files: map[string]string{"README.md": "stable content\n"},
+	})
+	ignBinary := buildIgnBinary(t)
+
+	withWorkingDir(t, tempDir, func() {
+		if err := app.Init(context.Background(), app.InitOptions{URL: "./template"}); err != nil {
+			t.Fatalf("Init failed: %v", err)
+		}
+		if _, err := app.Checkout(context.Background(), app.CheckoutOptions{OutputDir: "."}); err != nil {
+			t.Fatalf("Checkout failed: %v", err)
+		}
+
+		readmePath := filepath.Join(tempDir, "README.md")
+		oldTime := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
+		if err := os.Chtimes(readmePath, oldTime, oldTime); err != nil {
+			t.Fatalf("failed to set README.md mtime: %v", err)
+		}
+		beforeInfo, err := os.Stat(readmePath)
+		if err != nil {
+			t.Fatalf("failed to stat README.md: %v", err)
+		}
+
+		result := runIgnCLI(t, ignBinary, tempDir, "update", "--ref", "v2.0.0")
+		if result.exitCode != 0 {
+			t.Fatalf("ign update --ref exit = %d, stderr = %s", result.exitCode, result.stderr)
+		}
+
+		afterInfo, err := os.Stat(readmePath)
+		if err != nil {
+			t.Fatalf("failed to stat README.md after update: %v", err)
+		}
+		if !afterInfo.ModTime().Equal(beforeInfo.ModTime()) {
+			t.Fatalf("README.md mtime changed: before %s after %s", beforeInfo.ModTime(), afterInfo.ModTime())
+		}
+		if got := readFileString(t, readmePath); got != "stable content\n" {
+			t.Fatalf("README.md = %q, want unchanged content", got)
+		}
+		assertStoredUpdateRef(t, "v2.0.0")
+	})
+}
+
+func TestUpdateRefCLIDryRunPreviewsAndDoesNotPersistRef(t *testing.T) {
+	tempDir := t.TempDir()
+	templatePath := filepath.Join(tempDir, "template")
+	writeUpdateRefTemplate(t, templatePath, updateRefTemplateSpec{
+		Hash:  updateRefHash1,
+		Files: map[string]string{"README.md": "version one\n"},
+	})
+	ignBinary := buildIgnBinary(t)
+
+	withWorkingDir(t, tempDir, func() {
+		if err := app.Init(context.Background(), app.InitOptions{URL: "./template"}); err != nil {
+			t.Fatalf("Init failed: %v", err)
+		}
+		if _, err := app.Checkout(context.Background(), app.CheckoutOptions{OutputDir: "."}); err != nil {
+			t.Fatalf("Checkout failed: %v", err)
+		}
+
+		writeUpdateRefTemplate(t, templatePath, updateRefTemplateSpec{
+			Hash:  updateRefHash2,
+			Files: map[string]string{"README.md": "version two\n"},
+		})
+
+		result := runIgnCLI(t, ignBinary, tempDir, "update", "--ref", "v2.0.0", "--dry-run")
+		if result.exitCode != 0 {
+			t.Fatalf("ign update --ref --dry-run exit = %d, stderr = %s", result.exitCode, result.stderr)
+		}
+		if !strings.Contains(result.stdout, "[DRY RUN]") {
+			t.Fatalf("dry-run stdout = %q, want [DRY RUN] preview", result.stdout)
+		}
+		if got := readFileString(t, filepath.Join(tempDir, "README.md")); got != "version one\n" {
+			t.Fatalf("README.md = %q, want unchanged dry-run content", got)
+		}
+		assertStoredUpdateRef(t, "")
+	})
+}
+
+func TestUpdateRefCLIOverwriteRespectsOverwriteIgnore(t *testing.T) {
+	tempDir := t.TempDir()
+	templatePath := filepath.Join(tempDir, "template")
+	writeUpdateRefTemplate(t, templatePath, updateRefTemplateSpec{
+		Hash:            updateRefHash1,
+		OverwriteIgnore: "protected.txt\n",
+		Files: map[string]string{
+			"generated.txt": "generated v1\n",
+			"protected.txt": "protected v1\n",
+		},
+	})
+	ignBinary := buildIgnBinary(t)
+
+	withWorkingDir(t, tempDir, func() {
+		if err := app.Init(context.Background(), app.InitOptions{URL: "./template"}); err != nil {
+			t.Fatalf("Init failed: %v", err)
+		}
+		if _, err := app.Checkout(context.Background(), app.CheckoutOptions{OutputDir: "."}); err != nil {
+			t.Fatalf("Checkout failed: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(tempDir, "protected.txt"), []byte("user-owned\n"), 0644); err != nil {
+			t.Fatalf("failed to write user-owned protected file: %v", err)
+		}
+
+		writeUpdateRefTemplate(t, templatePath, updateRefTemplateSpec{
+			Hash:            updateRefHash2,
+			OverwriteIgnore: "protected.txt\n",
+			Files: map[string]string{
+				"generated.txt": "generated v2\n",
+				"protected.txt": "protected v2\n",
+			},
+		})
+
+		result := runIgnCLI(t, ignBinary, tempDir, "update", "--ref", "v2.0.0", "--overwrite", "--yes")
+		if result.exitCode != 0 {
+			t.Fatalf("ign update --ref --overwrite --yes exit = %d, stderr = %s", result.exitCode, result.stderr)
+		}
+		if got := readFileString(t, filepath.Join(tempDir, "generated.txt")); got != "generated v2\n" {
+			t.Fatalf("generated.txt = %q, want overwritten generated content", got)
+		}
+		if got := readFileString(t, filepath.Join(tempDir, "protected.txt")); got != "user-owned\n" {
+			t.Fatalf("protected.txt = %q, want user-owned content preserved", got)
+		}
+		assertStoredUpdateRef(t, "v2.0.0")
+	})
+}
+
+func seedSimpleTemplateVars(t *testing.T) {
+	t.Helper()
+
+	ignVarPath := filepath.Join(model.IgnConfigDir, model.IgnVarFile)
+	ignVar := loadIgnVar(t, ignVarPath)
+	if ignVar.Variables == nil {
+		ignVar.Variables = map[string]interface{}{}
+	}
+	ignVar.Variables["project_name"] = "demo"
+	ignVar.Variables["port"] = 8080
+	ignVar.Variables["enable_feature"] = false
+	if err := config.SaveIgnVarJson(ignVarPath, &ignVar); err != nil {
+		t.Fatalf("failed to save ign-var.json: %v", err)
+	}
+}
+
+const (
+	updateRefHash1 = "1111111111111111111111111111111111111111111111111111111111111111"
+	updateRefHash2 = "2222222222222222222222222222222222222222222222222222222222222222"
+)
+
+type updateRefTemplateSpec struct {
+	Hash            string
+	OverwriteIgnore string
+	Files           map[string]string
+}
+
+func writeUpdateRefTemplate(t *testing.T, templatePath string, spec updateRefTemplateSpec) {
+	t.Helper()
+
+	if err := os.RemoveAll(templatePath); err != nil {
+		t.Fatalf("failed to reset template directory: %v", err)
+	}
+	if err := os.MkdirAll(templatePath, 0755); err != nil {
+		t.Fatalf("failed to create template directory: %v", err)
+	}
+
+	ignJSON := model.IgnJson{
+		Name:      "update-ref-template",
+		Version:   "1.0.0",
+		Hash:      spec.Hash,
+		Variables: map[string]model.VarDef{},
+	}
+	data, err := json.MarshalIndent(ignJSON, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal template config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(templatePath, model.IgnTemplateConfigFile), data, 0644); err != nil {
+		t.Fatalf("failed to write template config: %v", err)
+	}
+
+	if spec.OverwriteIgnore != "" {
+		if err := os.WriteFile(filepath.Join(templatePath, model.IgnOverwriteIgnoreFile), []byte(spec.OverwriteIgnore), 0644); err != nil {
+			t.Fatalf("failed to write overwrite ignore: %v", err)
+		}
+	}
+
+	for name, content := range spec.Files {
+		path := filepath.Join(templatePath, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatalf("failed to create template file directory: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("failed to write template file %s: %v", name, err)
+		}
+	}
+}
+
+func withWorkingDir(t *testing.T, dir string, fn func()) {
+	t.Helper()
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current directory: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("failed to change to temp directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(origDir); err != nil {
+			t.Fatalf("failed to restore working directory: %v", err)
+		}
+	}()
+	fn()
+}
+
+func assertStoredUpdateRef(t *testing.T, want string) {
+	t.Helper()
+
+	loaded, err := config.LoadIgnConfig(filepath.Join(model.IgnConfigDir, model.IgnProjectConfigFile))
+	if err != nil {
+		t.Fatalf("failed to load ign config: %v", err)
+	}
+	if loaded.Template.Ref != want {
+		t.Fatalf("stored ref = %q, want %q", loaded.Template.Ref, want)
+	}
+}

--- a/test/integration/vars_test.go
+++ b/test/integration/vars_test.go
@@ -1,0 +1,259 @@
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/tacogips/ign/internal/app"
+	"github.com/tacogips/ign/internal/template/model"
+)
+
+func TestVarsCommandListsTemplateVariables(t *testing.T) {
+	tempDir := t.TempDir()
+	templatePath := copyFixtureToTemp(t, "simple-template", tempDir)
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current directory: %v", err)
+	}
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("failed to change to temp directory: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	if err := app.Init(context.Background(), app.InitOptions{URL: templatePath}); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	beforeIgnConfig := readFileString(t, filepath.Join(model.IgnConfigDir, model.IgnProjectConfigFile))
+	beforeIgnVar := readFileString(t, filepath.Join(model.IgnConfigDir, model.IgnVarFile))
+
+	result, err := app.InspectVars(context.Background(), app.VarsOptions{})
+	if err != nil {
+		t.Fatalf("InspectVars failed: %v", err)
+	}
+	if !result.DeclarationsAvailable {
+		t.Fatalf("declarations unavailable: %v", result.DeclarationError)
+	}
+
+	rows := integrationRowsByName(result.Rows)
+	for _, name := range []string{"project_name", "port", "enable_feature"} {
+		if _, ok := rows[name]; !ok {
+			t.Fatalf("missing vars row %q in %#v", name, result.Rows)
+		}
+	}
+
+	if got := readFileString(t, filepath.Join(model.IgnConfigDir, model.IgnProjectConfigFile)); got != beforeIgnConfig {
+		t.Fatal("InspectVars mutated .ign/ign.json")
+	}
+	if got := readFileString(t, filepath.Join(model.IgnConfigDir, model.IgnVarFile)); got != beforeIgnVar {
+		t.Fatal("InspectVars mutated .ign/ign-var.json")
+	}
+}
+
+func TestVarsCommandUnsetRequiredMissing(t *testing.T) {
+	tempDir := t.TempDir()
+	templatePath := copyFixtureToTemp(t, "simple-template", tempDir)
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current directory: %v", err)
+	}
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("failed to change to temp directory: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	if err := app.Init(context.Background(), app.InitOptions{URL: templatePath}); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	ignVarPath := filepath.Join(model.IgnConfigDir, model.IgnVarFile)
+	data, err := os.ReadFile(ignVarPath)
+	if err != nil {
+		t.Fatalf("failed to read ign-var.json: %v", err)
+	}
+	var ignVar model.IgnVarJson
+	if err := json.Unmarshal(data, &ignVar); err != nil {
+		t.Fatalf("failed to parse ign-var.json: %v", err)
+	}
+	delete(ignVar.Variables, "project_name")
+	updated, err := json.MarshalIndent(ignVar, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal ign-var.json: %v", err)
+	}
+	if err := os.WriteFile(ignVarPath, updated, 0644); err != nil {
+		t.Fatalf("failed to write ign-var.json: %v", err)
+	}
+
+	result, err := app.InspectVars(context.Background(), app.VarsOptions{})
+	if err != nil {
+		t.Fatalf("InspectVars failed: %v", err)
+	}
+	unset := app.FilterUnsetVars(result)
+	if unset.RequiredUnsetCount != 1 {
+		t.Fatalf("RequiredUnsetCount = %d, want 1", unset.RequiredUnsetCount)
+	}
+	if len(unset.Rows) != 1 || unset.Rows[0].Name != "project_name" {
+		t.Fatalf("unset rows = %#v, want project_name only", unset.Rows)
+	}
+}
+
+func TestVarsCLICommandTableJSONAndUnsetExit(t *testing.T) {
+	tempDir := t.TempDir()
+	templatePath := copyFixtureToTemp(t, "simple-template", tempDir)
+	ignBinary := buildIgnBinary(t)
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current directory: %v", err)
+	}
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("failed to change to temp directory: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	if err := app.Init(context.Background(), app.InitOptions{URL: templatePath}); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	table := runIgnCLI(t, ignBinary, tempDir, "vars")
+	if table.exitCode != 0 {
+		t.Fatalf("ign vars exit = %d, stderr = %s", table.exitCode, table.stderr)
+	}
+	for _, want := range []string{"NAME", "TYPE", "REQUIRED", "DEFAULT", "CURRENT", "DESCRIPTION", "project_name"} {
+		if !strings.Contains(table.stdout, want) {
+			t.Fatalf("ign vars stdout %q does not contain %q", table.stdout, want)
+		}
+	}
+
+	jsonRun := runIgnCLI(t, ignBinary, tempDir, "vars", "--json")
+	if jsonRun.exitCode != 0 {
+		t.Fatalf("ign vars --json exit = %d, stderr = %s", jsonRun.exitCode, jsonRun.stderr)
+	}
+	var decoded app.VarsResult
+	if err := json.Unmarshal([]byte(jsonRun.stdout), &decoded); err != nil {
+		t.Fatalf("ign vars --json stdout is not valid JSON: %v\n%s", err, jsonRun.stdout)
+	}
+	if len(decoded.Rows) == 0 {
+		t.Fatal("ign vars --json returned no rows")
+	}
+
+	unsetSatisfied := runIgnCLI(t, ignBinary, tempDir, "vars", "--unset")
+	if unsetSatisfied.exitCode != 0 {
+		t.Fatalf("ign vars --unset exit = %d, stderr = %s", unsetSatisfied.exitCode, unsetSatisfied.stderr)
+	}
+	if strings.Contains(unsetSatisfied.stdout, "project_name") {
+		t.Fatalf("ign vars --unset stdout = %q, want no satisfied variables", unsetSatisfied.stdout)
+	}
+
+	removeIgnVar(t, "project_name")
+
+	unsetMissing := runIgnCLI(t, ignBinary, tempDir, "vars", "--unset")
+	if unsetMissing.exitCode != 1 {
+		t.Fatalf("ign vars --unset missing exit = %d, stderr = %s", unsetMissing.exitCode, unsetMissing.stderr)
+	}
+	if !strings.Contains(unsetMissing.stdout, "project_name") {
+		t.Fatalf("ign vars --unset missing stdout = %q, want project_name", unsetMissing.stdout)
+	}
+
+	jsonUnsetMissing := runIgnCLI(t, ignBinary, tempDir, "vars", "--json", "--unset")
+	if jsonUnsetMissing.exitCode != 1 {
+		t.Fatalf("ign vars --json --unset missing exit = %d, stderr = %s", jsonUnsetMissing.exitCode, jsonUnsetMissing.stderr)
+	}
+	var decodedUnset app.VarsResult
+	if err := json.Unmarshal([]byte(jsonUnsetMissing.stdout), &decodedUnset); err != nil {
+		t.Fatalf("ign vars --json --unset stdout is not valid JSON: %v\n%s", err, jsonUnsetMissing.stdout)
+	}
+	if decodedUnset.RequiredUnsetCount != 1 {
+		t.Fatalf("RequiredUnsetCount = %d, want 1", decodedUnset.RequiredUnsetCount)
+	}
+}
+
+func integrationRowsByName(rows []app.VarsRow) map[string]app.VarsRow {
+	result := make(map[string]app.VarsRow, len(rows))
+	for _, row := range rows {
+		result[row.Name] = row
+	}
+	return result
+}
+
+func readFileString(t *testing.T, path string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func removeIgnVar(t *testing.T, name string) {
+	t.Helper()
+
+	ignVarPath := filepath.Join(model.IgnConfigDir, model.IgnVarFile)
+	data, err := os.ReadFile(ignVarPath)
+	if err != nil {
+		t.Fatalf("failed to read ign-var.json: %v", err)
+	}
+	var ignVar model.IgnVarJson
+	if err := json.Unmarshal(data, &ignVar); err != nil {
+		t.Fatalf("failed to parse ign-var.json: %v", err)
+	}
+	delete(ignVar.Variables, name)
+	updated, err := json.MarshalIndent(ignVar, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal ign-var.json: %v", err)
+	}
+	if err := os.WriteFile(ignVarPath, updated, 0644); err != nil {
+		t.Fatalf("failed to write ign-var.json: %v", err)
+	}
+}
+
+func buildIgnBinary(t *testing.T) string {
+	t.Helper()
+
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to locate integration test file")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(currentFile), "..", ".."))
+	binaryPath := filepath.Join(t.TempDir(), "ign-test")
+	cmd := exec.Command("go", "build", "-o", binaryPath, "./cmd/ign")
+	cmd.Dir = repoRoot
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to build ign binary: %v\n%s", err, string(output))
+	}
+	return binaryPath
+}
+
+type ignCLIResult struct {
+	stdout   string
+	stderr   string
+	exitCode int
+}
+
+func runIgnCLI(t *testing.T, binaryPath, workDir string, args ...string) ignCLIResult {
+	t.Helper()
+
+	cmd := exec.Command(binaryPath, args...)
+	cmd.Dir = workDir
+	cmd.Env = append(os.Environ(), "GITHUB_TOKEN=", "GH_TOKEN=", "PATH=/nonexistent")
+	stdout, err := cmd.Output()
+	stderr := ""
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		stderr = string(exitErr.Stderr)
+		return ignCLIResult{stdout: string(stdout), stderr: stderr, exitCode: exitErr.ExitCode()}
+	}
+	if err != nil {
+		t.Fatalf("failed to run ign %v: %v", args, err)
+	}
+	return ignCLIResult{stdout: string(stdout), stderr: stderr, exitCode: 0}
+}


### PR DESCRIPTION
## Summary

This PR contains two commits from a full-codebase review-and-improve session.

### fix: remediate verified defects from full-codebase review (c647c2e)

Thirteen verified defects fixed across the update, rewind, checkout, CLI, and template-engine layers:

- ign update now generates before persisting config/hash, with rollback, so a failed update can no longer permanently masquerade as up to date
- All .ign JSON writes are atomic (temp file + rename), preventing config corruption on interrupted writes
- Rewind manifest-less fallback deletes only files whose content matches generated output, protecting user-owned files
- --quiet no longer suppresses error output; checkout errors instead of exiting 0 when .ign exists without --force; errors print once; template check returns an error instead of calling os.Exit inside RunE
- Relative @ign-include resolution fixed (previously never worked); non-greedy @ign-raw matching fixes content corruption with two directives on one line; branch-only /tree/ URLs and trailing .git are parsed correctly; tar extraction gained zip-slip and symlink containment guards; switch gained --var and deferred config setup; invalid variable patterns fail fast instead of trapping the prompt loop

### feat: add ign vars command and ign update --ref retargeting (874926b)

- ign vars: table of template variable declarations merged with current .ign/ign-var.json values; --json for scripting; --unset exits 1 when required variables are unset (CI gate); offline fallback to local values
- ign update --ref: retargets the tracked branch/tag/commit through the normal update flow with all overwrite protections, replacing the destructive rewind-and-checkout workaround; ref format validated before any network call

## Verification

- go build ./..., go vet ./..., gofmt -l: clean
- go test ./... including the integration suite: all pass
- Manual smoke test: ign template new -> init -> vars / vars --unset / vars --json -> update --ref validation -> update (no changes)